### PR TITLE
Better filtering for imagegen history, in progress

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "MaestroTutor-GeminiEdition_8_checkpoint",
+  "name": "MaestroTutor-GeminiEdition_11_checkpoint",
   "description": "A fully client-side React application for language learning powered by Google Gemini API. Features real-time voice conversation, image-based context, and personalized tutoring without external backend dependencies.",
   "requestFramePermissions": [
     "camera",


### PR DESCRIPTION
Imagegen history should not have other media than images. Made changes to GeminiService to filter history. So far getting error "Image Gen Error: {"error":{"code":400,"message":"Audio input modality is not enabled for this model","status":"INVALID_ARGUMENT"}}" and cant see the console.debug payload summary. This is still the concept for the filtering, needs more work.