### PR TITLE
Status flag collapses, open on click

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "MaestroTutor-GeminiEdition_24_checkpoint",
+  "name": "MaestroTutor-GeminiEdition_25_checkpoint",
   "description": "A fully client-side React application for language learning powered by Google Gemini API. Features real-time voice conversation, image-based context, and personalized tutoring without external backend dependencies.",
   "requestFramePermissions": [
     "camera",

--- a/src/components/CollapsedMaestroStatus.tsx
+++ b/src/components/CollapsedMaestroStatus.tsx
@@ -24,7 +24,8 @@ interface CollapsedMaestroStatusProps {
   uiBusyTaskTags?: string[];
   targetLanguageFlag?: string;
   targetLanguageTitle?: string;
-  className?: string; // Allow passing text color class override
+  className?: string;
+  isExpanded?: boolean;
 }
 
 // Helper to get configuration for the parent container (The Flag)
@@ -53,7 +54,15 @@ export const getStatusConfig = (stage: MaestroActivityStage, uiBusyTaskTags: str
   }
 };
 
-const CollapsedMaestroStatus: React.FC<CollapsedMaestroStatusProps> = ({ stage, t, uiBusyTaskTags, targetLanguageFlag, targetLanguageTitle, className }) => {
+const CollapsedMaestroStatus: React.FC<CollapsedMaestroStatusProps> = ({ 
+  stage, 
+  t, 
+  uiBusyTaskTags, 
+  targetLanguageFlag, 
+  targetLanguageTitle, 
+  className,
+  isExpanded = true 
+}) => {
   let iconElement: React.ReactNode = null;
   let textKey: string = "";
   let titleKey: string = "";
@@ -123,14 +132,16 @@ const CollapsedMaestroStatus: React.FC<CollapsedMaestroStatusProps> = ({ stage, 
               return <span key={key} className={`${base} rounded-full bg-current opacity-50 inline-block`} title={tag} />;
           }
         };
+        // Show first icon always, others if expanded
+        const primaryTag = activeTags[0];
         iconElement = (
           <div className="flex items-center gap-1">
-            {activeTags.map((tag, i) => tagToIcon(tag, i))}
+             {tagToIcon(primaryTag, 0)}
+             {isExpanded && activeTags.slice(1).map((tag, i) => tagToIcon(tag, i + 1))}
           </div>
         );
         
         // Determine text based on the *first* recognized tag priority
-        const primaryTag = activeTags[0]; 
         if (primaryTag === 'bubble-annotate' || primaryTag === 'composer-annotate') {
            textKey = 'chat.header.annotating';
            titleKey = 'chat.header.annotating';
@@ -169,10 +180,15 @@ const CollapsedMaestroStatus: React.FC<CollapsedMaestroStatusProps> = ({ stage, 
   }
 
   return (
-    <div className={`flex items-center space-x-2 ${className || baseTextColor}`} title={t(titleKey)}>
+    <div className={`flex items-center ${className || baseTextColor}`} title={t(titleKey)}>
       {iconElement}
-      {targetLanguageFlag && <span className="text-base" title={targetLanguageTitle}>{targetLanguageFlag}</span>}
-      <span className="text-xs font-semibold uppercase tracking-wide whitespace-nowrap">{t(textKey)}</span>
+      
+      <div 
+        className={`flex items-center overflow-hidden transition-all duration-500 ease-in-out ${isExpanded ? 'max-w-xs opacity-100 ml-2' : 'max-w-0 opacity-0 ml-0'}`}
+      >
+        {targetLanguageFlag && <span className="text-base mr-2" title={targetLanguageTitle}>{targetLanguageFlag}</span>}
+        <span className="text-xs font-semibold uppercase tracking-wide whitespace-nowrap">{t(textKey)}</span>
+      </div>
     </div>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,12 @@
 
-import React, { forwardRef, useState, useEffect } from 'react';
+import React, { forwardRef, useState, useEffect, useRef } from 'react';
 import CollapsedMaestroStatus, { getStatusConfig } from './CollapsedMaestroStatus';
 import { LanguageDefinition } from '../../constants';
 import { ChatMessage, MaestroActivityStage, LanguagePair } from '../../types';
 import { TranslationReplacements } from '../../translations/index';
 
 interface HeaderProps {
-  isTopbarOpen: boolean; // Kept for prop compatibility, but functionality changed
+  isTopbarOpen: boolean; // Kept for prop compatibility
   setIsTopbarOpen: (open: boolean) => void;
   maestroActivityStage: MaestroActivityStage;
   t: (key: string, replacements?: TranslationReplacements) => string;
@@ -25,16 +25,33 @@ const Header = forwardRef<HTMLDivElement, HeaderProps>(({
   selectedLanguagePair,
   onLanguageSelectorClick,
 }, ref) => {
-  // Determine if we should show the full flag
-  const isBusy = uiBusyTaskTags.length > 0;
-  const isActive = maestroActivityStage !== 'idle' && maestroActivityStage !== 'observing_low';
-  
-  // Auto-expand logic based on state + hover
-  const [isHovered, setIsHovered] = useState(false);
-  
-  // The flag is expanded if the system is doing something (speaking/listening), 
-  // if there are UI tasks (uploading/annotating), or if the user hovers.
-  const isExpanded = isActive || isBusy || isHovered;
+  // Explicit open state managed by user interaction
+  const [isOpen, setIsOpen] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  // Auto-close after 5 seconds when opened
+  useEffect(() => {
+    if (isOpen) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => {
+        setIsOpen(false);
+      }, 5000);
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [isOpen]);
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (!isOpen) {
+      // First click: Open the flag to show text
+      e.stopPropagation();
+      setIsOpen(true);
+    } else {
+      // Second click (while open): Trigger the actual action (Language Selector)
+      onLanguageSelectorClick(e);
+    }
+  };
 
   const statusConfig = getStatusConfig(maestroActivityStage, uiBusyTaskTags);
 
@@ -43,29 +60,28 @@ const Header = forwardRef<HTMLDivElement, HeaderProps>(({
       {/* 
         Maestro Status Flag 
         Positioned fixed top-left. 
-        Slides out from the left edge.
+        Defaults to a small icon-only view. Expands on click.
       */}
       <div 
         ref={ref}
-        className={`fixed top-4 left-0 z-50 transition-all duration-300 ease-out shadow-md border-y border-r rounded-r-full flex items-center
+        className={`fixed top-4 left-0 z-50 transition-all duration-500 ease-out shadow-md border-y border-r rounded-r-full flex items-center cursor-pointer
           ${statusConfig.color} ${statusConfig.borderColor}
-          ${isExpanded ? 'translate-x-0 pr-4 pl-3 py-1.5' : '-translate-x-2 pl-4 pr-3 py-1.5 opacity-80 hover:translate-x-0 hover:opacity-100'}
+          ${isOpen ? 'pr-4 pl-3 py-1.5 translate-x-0' : 'pl-3 pr-1 py-1.5 -translate-x-1 hover:translate-x-0'}
         `}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        onClick={onLanguageSelectorClick}
+        onClick={handleClick}
         role="status"
         aria-live="polite"
-        style={{ cursor: 'pointer' }}
+        title={!isOpen ? "Click to view status" : undefined}
       >
-        <div className={`transition-opacity duration-300 ${isExpanded ? 'opacity-100' : 'opacity-70'}`}>
+        <div className={`transition-opacity duration-300`}>
           <CollapsedMaestroStatus
             stage={maestroActivityStage}
             t={t}
             uiBusyTaskTags={uiBusyTaskTags}
-            targetLanguageFlag={isExpanded && selectedLanguagePair ? targetLanguageDef?.flag : undefined}
+            targetLanguageFlag={selectedLanguagePair ? targetLanguageDef?.flag : undefined}
             targetLanguageTitle={selectedLanguagePair ? t('header.targetLanguageTitle', { language: targetLanguageDef?.displayName || '' }) : undefined}
             className={statusConfig.textColor}
+            isExpanded={isOpen}
           />
         </div>
       </div>


### PR DESCRIPTION
Maestro and ui task status flag collapses by default, reveals full flag on click, and second click still opens language selection in the input area. Collapsed flag reveals one ui task or maestro status icon, full flag shows text and all active ui task and/or maestro status icons.