### PR TITLE
Fix incorrect path error

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "MaestroTutor-GeminiEdition_29_checkpoint",
+  "name": "MaestroTutor-GeminiEdition_30_checkpoint",
   "description": "A fully client-side React application for language learning powered by Google Gemini API. Features real-time voice conversation, image-based context, and personalized tutoring without external backend dependencies.",
   "requestFramePermissions": [
     "camera",

--- a/src/components/chat/InputArea.tsx
+++ b/src/components/chat/InputArea.tsx
@@ -14,7 +14,7 @@ import SttLanguageSelector from './SttLanguageSelector';
 import LanguageSelectorGlobe from './LanguageSelectorGlobe';
 import { getMaestroProfileImageDB, setMaestroProfileImageDB, clearMaestroProfileImageDB, MaestroProfileAsset } from '../../services/assets';
 import { getGlobalProfileDB, setGlobalProfileDB } from '../../services/globalProfile';
-import { uploadMediaToFiles, deleteFileByNameOrUri } from '../../../services/geminiService';
+import { uploadMediaToFiles, deleteFileByNameOrUri } from '../../services/geminiService';
 import { DB_NAME } from '../../storage/db';
 import { uniq } from '../../utils/common';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src", "index.tsx", "App.tsx", "hooks", "types.ts", "constants.tsx", "translations", "services"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,11 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, (process as any).cwd(), '');
   return {
     plugins: [react()],
+    resolve: {
+      alias: {
+        '@': '/src'
+      }
+    },
     define: {
       'process.env.API_KEY': JSON.stringify(env.API_KEY)
     }


### PR DESCRIPTION
Fix to error "Uncaught TypeError: Failed to resolve module specifier "@/services/geminiService". Relative references must start with either "/", "./", or "../"." 

Update vite.config.ts to define the @ alias pointing to /src. 
+++++
    resolve: {
      alias: {
        '@': '/src'
      }
    },

Update tsconfig.json to add baseUrl and paths configuration for @/*. 
++++
    "baseUrl": ".",
    "paths": {
      "@/*": ["src/*"]
    }

Update src/components/chat/InputArea.tsx to fix the import path for geminiService.

from '../../../services/geminiService'; --> from '../../services/geminiService';