### PR TITLE
feat: Improve and simplify some features

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -404,8 +404,9 @@ const AppShell: React.FC = () => {
     scheduleReengagement,
     cancelReengagement,
     handleUserActivity,
-    isReengagementToken: _isReengagementToken,
-    setReengagementPhase: _setReengagementPhase,
+    // Intentionally unused - destructured to prevent "unused export" warnings in hook
+    isReengagementToken: _unusedIsReengagementToken,
+    setReengagementPhase: _unusedSetReengagementPhase,
   } = useSmartReengagement({
     settings,
     isLoadingHistory,
@@ -447,9 +448,6 @@ const AppShell: React.FC = () => {
     scheduleReengagementRef.current = scheduleReengagement;
     cancelReengagementRef.current = cancelReengagement;
   }, [scheduleReengagement, cancelReengagement]);
-
-  void _isReengagementToken;
-  void _setReengagementPhase;
 
   // ============================================================
   // EFFECTS - Side Effects and Synchronization
@@ -753,7 +751,7 @@ const AppShell: React.FC = () => {
               });
               const pairId = settingsRef.current.selectedLanguagePairId;
               if (pairId) {
-                (async () => { try { await setChatMetaDB(pairId, { bookmarkMessageId: id }); } catch {} })();
+                (async () => { try { await setChatMetaDB(pairId, { bookmarkMessageId: id }); } catch (e) { console.error(`[AppShell] Failed to persist bookmark for pairId=${pairId}, messageId=${id}:`, e); } })();
               }
             }}
             bookmarkedMessageId={settingsRef.current.historyBookmarkMessageId || null}

--- a/src/app/hooks/useAppAssets.ts
+++ b/src/app/hooks/useAppAssets.ts
@@ -31,9 +31,15 @@ export const useAppAssets = ({
       try {
         const a = await getMaestroProfileImageDB();
         if (a && (a.dataUrl || a.uri)) {
-          const nextMime = (a?.mimeType && typeof a.mimeType === 'string')
-            ? a.mimeType
-            : (a?.dataUrl?.startsWith('data:image/') ? 'image/svg+xml' : null);
+          // Parse MIME from mimeType field or extract from dataUrl
+          let nextMime: string | null = null;
+          if (a?.mimeType && typeof a.mimeType === 'string') {
+            nextMime = a.mimeType;
+          } else if (a?.dataUrl) {
+            // Extract MIME from data URL: data:<mime>;base64,... or data:<mime>,...
+            const mimeMatch = a.dataUrl.match(/^data:([^;,]+)[;,]/);
+            nextMime = mimeMatch ? mimeMatch[1] : null;
+          }
           maestroAvatarUriRef.current = a.uri || null;
           maestroAvatarMimeTypeRef.current = nextMime;
           setMaestroAvatar(a.dataUrl || a.uri || null, nextMime);
@@ -83,9 +89,8 @@ export const useAppAssets = ({
         const mimeType = event?.detail?.mimeType as string | undefined;
         const dataUrl = event?.detail?.dataUrl as string | undefined;
         maestroAvatarUriRef.current = uri || null;
-        if (mimeType && typeof mimeType === 'string') {
-          maestroAvatarMimeTypeRef.current = mimeType;
-        }
+        // Explicitly set to the provided mimeType or null to avoid stale values
+        maestroAvatarMimeTypeRef.current = (mimeType && typeof mimeType === 'string') ? mimeType : null;
         setMaestroAvatar(dataUrl || uri || null, mimeType || null);
       } catch { /* ignore */ }
     };

--- a/src/app/hooks/useAppLifecycle.ts
+++ b/src/app/hooks/useAppLifecycle.ts
@@ -15,15 +15,11 @@ export const useAppLifecycle = (t: TranslationFunction) => {
     document.title = t(APP_TITLE_KEY);
   }, [t]);
 
+  // Remove splash screen immediately - user sees chat as first thing
   useEffect(() => {
     const splashScreen = document.getElementById('splash-screen');
     if (splashScreen) {
-      setTimeout(() => {
-        splashScreen.classList.add('fade-out');
-        splashScreen.addEventListener('transitionend', () => {
-          splashScreen.remove();
-        });
-      }, 200);
+      splashScreen.remove();
     }
   }, []);
 };

--- a/src/app/hooks/useAutoFetchSuggestions.ts
+++ b/src/app/hooks/useAutoFetchSuggestions.ts
@@ -39,8 +39,12 @@ export const useAutoFetchSuggestions = ({
       if (lastMessage && lastMessage.role === 'assistant' && !lastMessage.thinking && lastMessage.id !== lastFetchedSuggestionsForRef.current) {
         const textForSuggestions = lastMessage.rawAssistantResponse || (lastMessage.translations?.find(t => t.spanish)?.spanish) || "";
         if (textForSuggestions.trim()) {
-          fetchAndSetReplySuggestions(lastMessage.id, textForSuggestions, getHistoryRespectingBookmark(messagesRef.current));
+          // Set ref before fetch to prevent duplicate concurrent requests
+          // Note: If fetch fails, we intentionally don't retry automatically.
+          // The ref marks this message as "attempted" - the user can manually
+          // trigger suggestions again or the next TTS end will try the new message.
           lastFetchedSuggestionsForRef.current = lastMessage.id;
+          fetchAndSetReplySuggestions(lastMessage.id, textForSuggestions, getHistoryRespectingBookmark(messagesRef.current));
         }
       }
     }

--- a/src/app/hooks/useAutoSendOnSilence.ts
+++ b/src/app/hooks/useAutoSendOnSilence.ts
@@ -49,29 +49,23 @@ export const useAutoSendOnSilence = ({
       return;
     }
 
-    const stripBracketedContent = (input: string | undefined | null): string => {
-      if (typeof input !== 'string') return '';
-      const without = input.replace(/\[[^\]]*\]/g, ' ');
-      return without.replace(/\s+/g, ' ').trim();
-    };
-
-    const text = stripBracketedContent(transcript || '');
+    const text = (transcript || '').trim();
     clearAutoSend();
 
     if (text.length < 2) {
       return;
     }
 
-    autoSendSnapshotRef.current = stripBracketedContent(transcript || '');
+    autoSendSnapshotRef.current = text;
     autoSendTimerRef.current = window.setTimeout(() => {
       const snap = autoSendSnapshotRef.current;
-      const current = stripBracketedContent(transcript || '');
+      const current = (transcript || '').trim();
       if (
         settingsRef.current.stt.enabled &&
         !isSendingRef.current &&
         !speechIsSpeakingRef.current &&
         current.length >= 2 &&
-        stripBracketedContent(transcript || '') === snap
+        current === snap
       ) {
         clearTranscript();
         if (settingsRef.current.isSuggestionMode) {

--- a/src/app/hooks/useChatStore.ts
+++ b/src/app/hooks/useChatStore.ts
@@ -10,14 +10,12 @@
 
 import { useCallback, useRef, useEffect } from 'react';
 import { useShallow } from 'zustand/shallow';
-import { useMaestroStore } from '../../store';
+import { useMaestroStore, MAX_VISIBLE_MESSAGES_DEFAULT } from '../../store';
 import { ChatMessage, TtsAudioCacheEntry, ReplySuggestion } from '../../core/types';
 import { safeSaveChatHistoryDB, setChatMetaDB } from '../../features/chat';
 import { setAppSettingsDB } from '../../features/session';
 import { isRealChatMessage } from '../../shared/utils/common';
 import type { TranslationFunction } from './useTranslations';
-
-const MAX_VISIBLE_MESSAGES_DEFAULT = 50;
 
 export interface UseChatStoreConfig {
   t: TranslationFunction;

--- a/src/app/hooks/useHardware.ts
+++ b/src/app/hooks/useHardware.ts
@@ -53,8 +53,8 @@ export interface UseHardwareReturn {
   captureSnapshot: (isForReengagement?: boolean) => Promise<{
     base64: string;
     mimeType: string;
-    llmBase64: string;
-    llmMimeType: string;
+    storageOptimizedBase64: string;
+    storageOptimizedMimeType: string;
   } | null>;
   /** Fetch available cameras */
   fetchAvailableCameras: () => Promise<void>;
@@ -256,8 +256,8 @@ export const useHardware = (config: UseHardwareConfig): UseHardwareReturn => {
   const captureSnapshot = useCallback(async (isForReengagement = false): Promise<{
     base64: string;
     mimeType: string;
-    llmBase64: string;
-    llmMimeType: string;
+    storageOptimizedBase64: string;
+    storageOptimizedMimeType: string;
   } | null> => {
     const errorSetter = isForReengagement ? setVisualContextCameraError : setSnapshotUserError;
     errorSetter(null);
@@ -334,7 +334,7 @@ export const useHardware = (config: UseHardwareConfig): UseHardwareReturn => {
 
       context.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
       const imageBase64 = canvas.toDataURL('image/jpeg', 0.9);
-      return { base64: imageBase64, mimeType: 'image/jpeg', llmBase64: imageBase64, llmMimeType: 'image/jpeg' };
+      return { base64: imageBase64, mimeType: 'image/jpeg', storageOptimizedBase64: imageBase64, storageOptimizedMimeType: 'image/jpeg' };
 
     } catch (err) {
       console.error(`Error capturing image (${isForReengagement ? 're-engagement' : 'snapshot'}):`, err);

--- a/src/app/hooks/useIdleReengagement.ts
+++ b/src/app/hooks/useIdleReengagement.ts
@@ -37,14 +37,11 @@ export const useIdleReengagement = ({
   const scheduleReengagementRef = useRef(scheduleReengagement);
   const cancelReengagementRef = useRef(cancelReengagement);
   
-  // Keep refs updated with latest callbacks
+  // Keep refs updated with latest callbacks (combined into single effect)
   useEffect(() => {
     scheduleReengagementRef.current = scheduleReengagement;
-  }, [scheduleReengagement]);
-  
-  useEffect(() => {
     cancelReengagementRef.current = cancelReengagement;
-  }, [cancelReengagement]);
+  }, [scheduleReengagement, cancelReengagement]);
 
   // Main effect - only depends on state values, not callbacks
   useEffect(() => {

--- a/src/app/hooks/useLiveSession.ts
+++ b/src/app/hooks/useLiveSession.ts
@@ -60,7 +60,7 @@ export interface UseLiveSessionConfig {
   setLiveVideoStream: React.Dispatch<React.SetStateAction<MediaStream | null>>;
   visualContextVideoRef: React.RefObject<HTMLVideoElement | null>;
   visualContextStreamRef: React.MutableRefObject<MediaStream | null>;
-  captureSnapshot: (isForReengagement?: boolean) => Promise<{ base64: string; mimeType: string; llmBase64: string; llmMimeType: string } | null>;
+  captureSnapshot: (isForReengagement?: boolean) => Promise<{ base64: string; mimeType: string; storageOptimizedBase64: string; storageOptimizedMimeType: string } | null>;
   
   // Speech
   isListening: boolean;
@@ -250,16 +250,16 @@ export const useLiveSession = (config: UseLiveSessionConfig): UseLiveSessionRetu
         text: userText,
         imageUrl: snapshotData?.base64,
         imageMimeType: snapshotData?.mimeType,
-        llmImageUrl: snapshotData?.llmBase64,
-        llmImageMimeType: snapshotData?.llmMimeType,
+        storageOptimizedImageUrl: snapshotData?.storageOptimizedBase64,
+        storageOptimizedImageMimeType: snapshotData?.storageOptimizedMimeType,
         recordedUtterance
       });
 
       // Background optimization and upload for live snapshots
       if (snapshotData && userMessageId) {
         (async () => {
-          let optimizedDataUrl = snapshotData.llmBase64;
-          let optimizedMime = snapshotData.llmMimeType;
+          let optimizedDataUrl = snapshotData.storageOptimizedBase64;
+          let optimizedMime = snapshotData.storageOptimizedMimeType;
           
           try {
             // 1. Optimize for local persistence (low-res)
@@ -276,17 +276,17 @@ export const useLiveSession = (config: UseLiveSessionConfig): UseLiveSessionRetu
             
             // 3. Update message with both low-res (local) and URI (remote)
             updateMessage(userMessageId, {
-              llmImageUrl: optimizedDataUrl,
-              llmImageMimeType: optimizedMime,
-              llmFileUri: up.uri,
-              llmFileMimeType: up.mimeType
+              storageOptimizedImageUrl: optimizedDataUrl,
+              storageOptimizedImageMimeType: optimizedMime,
+              uploadedFileUri: up.uri,
+              uploadedFileMimeType: up.mimeType
             });
           } catch (e) {
             console.warn('Upload failed', e);
             // Still update persistence image
             updateMessage(userMessageId, {
-              llmImageUrl: optimizedDataUrl,
-              llmImageMimeType: optimizedMime
+              storageOptimizedImageUrl: optimizedDataUrl,
+              storageOptimizedImageMimeType: optimizedMime
             });
           }
         })();
@@ -416,10 +416,10 @@ export const useLiveSession = (config: UseLiveSessionConfig): UseLiveSessionRetu
             updateMessage(assistantId, {
               imageUrl: res.base64Image,
               imageMimeType: res.mimeType,
-              llmImageUrl: optimized.dataUrl,
-              llmImageMimeType: optimized.mimeType,
-              llmFileUri: up.uri,
-              llmFileMimeType: up.mimeType,
+              storageOptimizedImageUrl: optimized.dataUrl,
+              storageOptimizedImageMimeType: optimized.mimeType,
+              uploadedFileUri: up.uri,
+              uploadedFileMimeType: up.mimeType,
               isGeneratingImage: false,
               imageGenerationStartTime: undefined
             });

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -15,10 +15,14 @@ export interface ChatMessage {
   imageUrl?: string;
   imageMimeType?: string;
   imageFileUri?: string;
-  llmImageUrl?: string;
-  llmImageMimeType?: string;
-  llmFileUri?: string;
-  llmFileMimeType?: string;
+  /** Optimized (lower res) image for local storage to reduce DB size */
+  storageOptimizedImageUrl?: string;
+  /** MIME type of the storage-optimized image */
+  storageOptimizedImageMimeType?: string;
+  /** Uploaded file URI (for sending to API after reload - note: expires after 48h) */
+  uploadedFileUri?: string;
+  /** MIME type of the uploaded file */
+  uploadedFileMimeType?: string;
   timestamp: number;
   thinking?: boolean;
   isGeneratingImage?: boolean;

--- a/src/features/chat/components/ChatMessageBubble.tsx
+++ b/src/features/chat/components/ChatMessageBubble.tsx
@@ -506,8 +506,8 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
     };
   }, [isAnnotating, annotationSourceUrl]);
 
-  const displayUrl = (message.imageUrl || message.llmImageUrl);
-  const displayMime = (message.imageMimeType || message.llmImageMimeType);
+  const displayUrl = (message.imageUrl || message.storageOptimizedImageUrl);
+  const displayMime = (message.imageMimeType || message.storageOptimizedImageMimeType);
   const isAttachmentAnImage = !!displayMime?.startsWith('image/');
   const isAttachmentAVideo = !!displayMime?.startsWith('video/');
   const isAttachmentAAudio = !!displayMime?.startsWith('audio/');

--- a/src/features/chat/components/InputArea.tsx
+++ b/src/features/chat/components/InputArea.tsx
@@ -3,7 +3,7 @@ import React, { useRef, useState, useEffect, useCallback, useMemo } from 'react'
 import { TranslationReplacements } from '../../../core/i18n/index';
 import { CameraDevice } from '../../../core/types';
 import { LanguageDefinition } from '../../../core/config/languages';
-import { LOCAL_STORAGE_SETTINGS_KEY, IMAGE_GEN_CAMERA_ID } from '../../../core/config/app';
+import { IMAGE_GEN_CAMERA_ID } from '../../../core/config/app';
 import { LiveSessionState, SttLanguageSelector } from '../../speech';
 import { 
   IconSend, IconPaperclip, IconMicrophone, IconXMark, IconCamera, 
@@ -856,18 +856,6 @@ const InputArea: React.FC<InputAreaProps> = ({
                 req.onblocked = () => { resolve(); };
             } catch { resolve(); }
             setTimeout(() => { if (!settled) resolve(); }, 1500);
-        });
-    } catch {}
-    try {
-        const keys: string[] = [];
-        for (let i = 0; i < window.localStorage.length; i++) {
-            const k = window.localStorage.key(i);
-            if (k) keys.push(k);
-        }
-        keys.forEach(k => {
-            if (k.startsWith('chatBackup:') || k === LOCAL_STORAGE_SETTINGS_KEY) {
-                try { window.localStorage.removeItem(k); } catch {}
-            }
         });
     } catch {}
   }, []);

--- a/src/features/chat/index.ts
+++ b/src/features/chat/index.ts
@@ -21,7 +21,6 @@ export { default as TextScrollwheel } from './components/TextScrollwheel';
 export { 
   getChatHistoryDB,
   safeSaveChatHistoryDB,
-  readBackupForPair,
   getChatMetaDB,
   setChatMetaDB,
   getAllChatHistoriesDB,

--- a/src/store/slices/hardwareSlice.ts
+++ b/src/store/slices/hardwareSlice.ts
@@ -86,10 +86,20 @@ export const createHardwareSlice: StateCreator<
   },
   
   setLiveVideoStream: (stream: MediaStream | null) => {
+    // Stop existing tracks before replacing to avoid leaks
+    const currentStream = get().liveVideoStream;
+    if (currentStream) {
+      currentStream.getTracks().forEach(track => track.stop());
+    }
     set({ liveVideoStream: stream });
   },
   
   setVisualContextStream: (stream: MediaStream | null) => {
+    // Stop existing tracks before replacing to avoid leaks
+    const currentStream = get().visualContextStream;
+    if (currentStream) {
+      currentStream.getTracks().forEach(track => track.stop());
+    }
     set({ visualContextStream: stream });
   },
   

--- a/src/store/slices/liveSessionSlice.ts
+++ b/src/store/slices/liveSessionSlice.ts
@@ -37,10 +37,12 @@ export const createLiveSessionSlice: StateCreator<
   
   // Actions
   setLiveSessionState: (state: LiveSessionState) => {
-    set({ liveSessionState: state });
-    if (state === 'connecting') {
-      set({ liveSessionError: null });
-    }
+    // Single atomic update to avoid transient inconsistent state
+    set((prev) => ({
+      ...prev,
+      liveSessionState: state,
+      liveSessionError: state === 'connecting' ? null : prev.liveSessionError
+    }));
   },
   
   setLiveSessionError: (error: string | null) => {


### PR DESCRIPTION
Improve and simplify some features to work better. 

Planned: Unified event (and activity) state management
Planning to use the ui tokens for most of the re engagement and visibility of status, previous methods to handle this would be replaced. Would check token to share and compare states, for example only use ui tokens for checking if should re engage or keep stt active or if tts is active etc.

Uploaded media uri is deleted for now before db save, but maybe would be better to keep uri and delete when uploading new to avoid bloating file api with quick reloads of app re uploading same files. Maybe just mark the uri to be deleted to know to re upload the url for uri and delete the old uri while uploading.