### PR TITLE
Added autopaste api key feature using capacitor clipboard

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -11,6 +11,7 @@ apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':aparajita-capacitor-secure-storage')
     implementation project(':capacitor-browser')
+    implementation project(':capacitor-clipboard')
     implementation project(':capacitor-preferences')
 
 }

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -8,5 +8,8 @@ project(':aparajita-capacitor-secure-storage').projectDir = new File('../node_mo
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
 
+include ':capacitor-clipboard'
+project(':capacitor-clipboard').projectDir = new File('../node_modules/@capacitor/clipboard/android')
+
 include ':capacitor-preferences'
 project(':capacitor-preferences').projectDir = new File('../node_modules/@capacitor/preferences/android')

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@aparajita/capacitor-secure-storage": "^7.1.6",
         "@capacitor/android": "^8.0.2",
         "@capacitor/browser": "^8.0.0",
+        "@capacitor/clipboard": "^8.0.0",
         "@capacitor/core": "^8.0.2",
         "@capacitor/preferences": "^8.0.0",
         "@google/genai": "^1.35.0",
@@ -1015,6 +1016,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@capacitor/clipboard": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/clipboard/-/clipboard-8.0.0.tgz",
+      "integrity": "sha512-nRgx07ThaoxOaTObZo/G39se9wA3oVgP0ooNO539P1TOZzWObwuXWObZgvaRJNpJfHVYcNe45Ylb8nlYl7VleA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/core": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@aparajita/capacitor-secure-storage": "^7.1.6",
     "@capacitor/android": "^8.0.2",
     "@capacitor/browser": "^8.0.0",
+    "@capacitor/clipboard": "^8.0.0",
     "@capacitor/core": "^8.0.2",
     "@capacitor/preferences": "^8.0.0",
     "@google/genai": "^1.35.0",


### PR DESCRIPTION
Added feature that autopastes the api key in when user returns back from the google ai studio with valid api key and clicks the input field. Helps people who have hard time figuring out how to paste in api key.