### PR TITLE
Tune image generation and camera handling

### DIFF
--- a/src/core/config/models.ts
+++ b/src/core/config/models.ts
@@ -23,16 +23,16 @@ export const DEFAULT_MODEL_REGISTRY_URL = 'https://ronitervo.github.io/MaestroTu
 
 const DEFAULT_GEMINI_MODELS: GeminiModelRegistry = {
   text: {
-    default: 'gemini-3-flash-preview-test',
-    aux: 'gemini-3-flash-preview-test',
-    translation: 'gemini-3-flash-preview-test',
+    default: 'gemini-3-flash-preview',
+    aux: 'gemini-3-flash-preview',
+    translation: 'gemini-3-flash-preview',
   },
   image: {
-    generation: 'gemini-2.5-flash-image-test',
+    generation: 'gemini-2.5-flash-image',
   },
   audio: {
-    tts: 'gemini-2.5-flash-preview-tts-test',
-    live: 'gemini-2.5-flash-native-audio-preview-12-2025-test',
+    tts: 'gemini-2.5-flash-preview-tts',
+    live: 'gemini-2.5-flash-native-audio-preview-12-2025',
   },
 };
 

--- a/src/features/chat/components/input/CameraControls.tsx
+++ b/src/features/chat/components/input/CameraControls.tsx
@@ -131,7 +131,14 @@ const CameraControls: React.FC<CameraControlsProps> = ({
               className={`p-2 cursor-pointer rounded-full transition-colors touch-manipulation ${isSuggestionMode ? 'text-gray-600 hover:text-black hover:bg-black/10' : 'hover:text-white hover:bg-blue-400/80'} ${isImageGenCameraSelected ? (isSuggestionMode ? 'text-purple-600' : 'text-purple-300 hover:text-purple-200') : ''}`}
               title={t('chat.camera.turnOn')}
             >
-              {isImageGenCameraSelected ? <IconSparkles className="w-5 h-5" /> : (currentCameraFacingMode === 'user' ? <IconCameraFront className="w-5 h-5" /> : <IconCamera className="w-5 h-5" />)}
+              {isImageGenCameraSelected ? (
+                <span className="relative inline-flex items-center justify-center w-5 h-5">
+                  {currentCameraFacingMode === 'user' ? <IconCameraFront className="w-5 h-5" /> : <IconCamera className="w-5 h-5" />}
+                  <IconSparkles className="w-3 h-3 absolute -top-1 -right-1" />
+                </span>
+              ) : (
+                currentCameraFacingMode === 'user' ? <IconCameraFront className="w-5 h-5" /> : <IconCamera className="w-5 h-5" />
+              )}
             </button>
           )}
         </>

--- a/src/features/chat/hooks/useTutorConversation.ts
+++ b/src/features/chat/hooks/useTutorConversation.ts
@@ -988,7 +988,7 @@ export const useTutorConversation = (config: UseTutorConversationConfig): UseTut
     const sanitizedUserHistoryForImage = params.sanitizedDerivedHistory as any;
     let finalResult: any = null;
 
-    for (let attempt = 0; attempt < 3; attempt++) {
+    for (let attempt = 0; attempt < 7; attempt++) {
       const prompt = IMAGE_GEN_USER_PROMPT_TEMPLATE.replace("{TEXT}", params.userMessageText);
       const userImgGenResult = await generateImage({
         history: sanitizedUserHistoryForImage,
@@ -1000,7 +1000,7 @@ export const useTutorConversation = (config: UseTutorConversationConfig): UseTut
       });
       finalResult = userImgGenResult;
       if ('base64Image' in userImgGenResult) break;
-      if (attempt < 2) await new Promise(r => setTimeout(r, 1500));
+      if (attempt < 6) await new Promise(r => setTimeout(r, 1500));
     }
 
     if (finalResult && 'base64Image' in finalResult) {
@@ -1036,9 +1036,8 @@ export const useTutorConversation = (config: UseTutorConversationConfig): UseTut
       } finally {
         setSendPrep(prev => (prev && prev.active ? { ...prev, label: t('chat.sendPrep.preparingMedia') || 'Preparing media...' } : prev));
       }
-    } else if (finalResult) {
+    } else {
       updateMessage(params.userMessageId, {
-        imageGenError: (finalResult as any).error,
         isGeneratingImage: false,
         imageGenerationStartTime: undefined
       });
@@ -1090,7 +1089,7 @@ export const useTutorConversation = (config: UseTutorConversationConfig): UseTut
       await new Promise(r => setTimeout(r, 0));
     } catch { /* ignore */ }
 
-    for (let attempt = 0; attempt < 3; attempt++) {
+    for (let attempt = 0; attempt < 7; attempt++) {
       const histForAssistantImgBase = historyForAssistantImageGen || baseForEnsure;
       let gpTextForAssistant: string | undefined = undefined;
       try {
@@ -1149,11 +1148,10 @@ export const useTutorConversation = (config: UseTutorConversationConfig): UseTut
           });
         }
         break;
-      } else if (attempt < 2) {
+      } else if (attempt < 6) {
         await new Promise(r => setTimeout(r, 1500));
       } else {
         updateMessage(params.thinkingMessageId, {
-          imageGenError: (assistantImgGenResult as any).error,
           isGeneratingImage: false,
           imageGenerationStartTime: undefined
         });

--- a/src/store/slices/settingsSlice.ts
+++ b/src/store/slices/settingsSlice.ts
@@ -14,6 +14,7 @@ import type { AppSettings, LanguagePair } from '../../core/types';
 import { getAppSettingsDB, setAppSettingsDB } from '../../features/session';
 import { ALL_LANGUAGES, STT_LANGUAGES, DEFAULT_NATIVE_LANG_CODE, DEFAULT_TARGET_LANG_CODE, type LanguageDefinition } from '../../core/config/languages';
 import { generateAllLanguagePairs, getPrimaryCode, parseLanguagePairId } from '../../shared/utils/languageUtils';
+import { IMAGE_GEN_CAMERA_ID } from '../../core/config/app';
 import type { MaestroStore } from '../maestroStore';
 
 // Generate language pairs once
@@ -24,8 +25,8 @@ const MAX_VISIBLE_MESSAGES_DEFAULT = 50;
 // Initial settings values
 export const initialSettings: AppSettings = {
   selectedLanguagePairId: null,
-  selectedCameraId: null,
-  sendWithSnapshotEnabled: false,
+  selectedCameraId: IMAGE_GEN_CAMERA_ID,
+  sendWithSnapshotEnabled: true,
   tts: {
     provider: 'gemini-live',
     speakNative: true,
@@ -38,7 +39,7 @@ export const initialSettings: AppSettings = {
   },
   smartReengagement: {
     thresholdSeconds: 45,
-    useVisualContext: false,
+    useVisualContext: true,
   },
   enableGoogleSearch: true,
   imageGenerationModeEnabled: true,


### PR DESCRIPTION
More descriptive closed camera state: image gen camera enabled will show sparkles plus camera icon showing what was prev state before closing.
More retries for image gen: from 3 to 7 and silent errors, no longer show error on chat message, traffic logs and console for developers are enough to check errors.
Image gen default: Image gen is enabled as default camera, so there is always media for user and assistand by default, more interesting.
Visual context default true, was not capturing visual context because remained false after toggling from image gen camera to normal camera, now toggled true by tefault
