### PR TITLE
cleaned off old json backup logic and more robust backup, load handling

### DIFF
--- a/src/core/i18n/en.ts
+++ b/src/core/i18n/en.ts
@@ -17,7 +17,6 @@ export const enTranslations: Record<string, string> = {
   "startPage.addMaestroAvatar": "Add Maestro avatar",
   "startPage.loadSuccess": "Successfully loaded and replaced {count} chat sessions!",
   "startPage.loadError": "Error loading chats. The file might be corrupted or in the wrong format.",
-  "startPage.loadLegacyTooLarge": "This legacy JSON backup is too large to load safely. Please export a new backup (NDJSON) from the latest app/web and try again.",
   "startPage.noChatsToSave": "There are no chat histories to save.",
   "startPage.saveError": "Error saving chats. Check the console for more details.",
 

--- a/src/features/session/components/SessionControls.tsx
+++ b/src/features/session/components/SessionControls.tsx
@@ -446,7 +446,7 @@ const SessionControls: React.FC = () => {
               <IconTrash className="w-4 h-4" />
             </button>
           </div>
-          <input type="file" ref={loadFileInputRef} onChange={handleLoadFileChange} accept=".json,.ndjson,.jsonl" className="hidden" />
+          <input type="file" ref={loadFileInputRef} onChange={handleLoadFileChange} accept=".ndjson,.jsonl" className="hidden" />
 
           {/* Right: Maestro Avatar Cluster */}
           <div


### PR DESCRIPTION
No functional changes other than more robust backup and load of chat histories and removed old json format support, Now streaming ndjson. Firefox and safari not supported, will give error message and direct to using chrome or edge to prevent crashing on large chat loading. 

Removed Firefox/Safari Blob Fallback: Added User-Friendly Browser Error
Added try/catch Around JSON.parse
Added Pre-Validation Before Clearing DB: Added Invalid Backup Format Error