### PR TITLE
feat: Image generation history turns reconstruction 

### DIFF
--- a/src/features/chat/services/chatHistory.ts
+++ b/src/features/chat/services/chatHistory.ts
@@ -264,7 +264,7 @@ export const setChatMetaDB = async (pairId: string, meta: ChatMeta | null): Prom
   });
 };
 
-type DerivedHistoryItem = { role: 'user' | 'assistant'; text?: string; rawAssistantResponse?: string; imageFileUri?: string; imageMimeType?: string };
+type DerivedHistoryItem = { role: 'user' | 'assistant'; text?: string; rawAssistantResponse?: string; imageFileUri?: string; imageMimeType?: string; chatSummary?: string };
 
 export const deriveHistoryForApi = (fullHistory: ChatMessage[], opts?: { roles?: Array<'user' | 'assistant' | 'system'>; maxMessages?: number; maxMediaToKeep?: number; contextSummary?: string; globalProfileText?: string; placeholderLatestUserMessage?: string; }) => {
     const { roles = ['user','assistant'], maxMessages, maxMediaToKeep = MAX_MEDIA_TO_KEEP, contextSummary, globalProfileText, placeholderLatestUserMessage } = opts || {};
@@ -292,6 +292,7 @@ export const deriveHistoryForApi = (fullHistory: ChatMessage[], opts?: { roles?:
         rawAssistantResponse: m.rawAssistantResponse,
         imageFileUri: uri,
         imageMimeType: mime,
+        chatSummary: m.chatSummary,
       };
     });
 


### PR DESCRIPTION
before payload seding to image generation reconstruct it so that only assistant turns appear to have images and user turns appear to have only text for better payload structure for consistant or more predictable generation results for same prompts.

Reduce image generation payload, keeping still payload up to all messages in between and up to 3 messages that have image. Image generation works best with 3 or less images (we have up to 4 because of the avatar, but the avatar appears as user turn so it is more ok that way to have more). We dont lose context too much for image quality, we add chat summary from the oldest message in history of the max we kept. That chat summary summarizes all of the dropped messages (bookmark would use this summary if it was set on this message, this is the same summary we would get at bookmark set to keep last x or keep up to message y)

uri verification and re upload: we did not check for 403 previously (no access, different api key used for upload than fetch). Now we check for 403 and still check for 404 (not found, likely expired). We also catche the result so that if different codepaths make calls before the uri is marked as deleted and replaced we dont call the api to check too many times for no reason. Once we get 404 or 403 there is no reason to recheck. As long as the image can be seen on chat (not dropped due to save size caps) the payload will always get fresh uri, reuploaded on 404 or 403 before payload sent, no change there. 

Progress updates on media optimization were integrated but the status was not passed to the ui (text input area). Fixed.