### PR TITLE
Ensure Maestro uri, better who is Maestro visual context for maestro.

### DIFF
--- a/src/api/gemini/generative.ts
+++ b/src/api/gemini/generative.ts
@@ -31,6 +31,10 @@ export const generateGeminiResponse = async (
       if (b64) parts.push({ inlineData: { data: b64, mimeType: h.imageMimeType } });
     }
 
+    if (h.avatarFileUri) {
+      parts.push({ fileData: { fileUri: h.avatarFileUri, mimeType: h.avatarMimeType || 'image/jpeg' } });
+    }
+
     if (parts.length > 0) {
       const role = h.role === 'assistant' ? 'model' : 'user';
       contents.push({ role, parts });

--- a/src/api/gemini/maestroAvatarEnsure.ts
+++ b/src/api/gemini/maestroAvatarEnsure.ts
@@ -1,0 +1,101 @@
+// Copyright 2025 Roni Tervo
+//
+// SPDX-License-Identifier: Apache-2.0
+import { getMaestroProfileImageDB, setMaestroProfileImageDB } from '../../core/db/assets';
+import { checkFileStatuses, uploadMediaToFiles } from './files';
+import { createAvatarWithOverlay } from '../../features/vision';
+
+const MAESTRO_URI_REFRESH_MS = (48 * 60 * 60 * 1000) - (5 * 60 * 1000); // 47h 55m
+
+let cachedRawUri: string | null = null;
+let cachedRawMimeType: string | null = null;
+let cachedRawUpdatedAt = 0;
+
+let cachedOverlayUri: string | null = null;
+let cachedOverlayMimeType: string | null = null;
+let cachedOverlayUpdatedAt = 0;
+
+export interface EnsuredAvatarResult {
+  rawUri: string | null;
+  rawMimeType: string | null;
+  overlayUri: string | null;
+  overlayMimeType: string | null;
+}
+
+const NULL_RESULT: EnsuredAvatarResult = { rawUri: null, rawMimeType: null, overlayUri: null, overlayMimeType: null };
+
+export const invalidateMaestroAvatarCache = (): void => {
+  cachedRawUri = null;
+  cachedRawMimeType = null;
+  cachedRawUpdatedAt = 0;
+  cachedOverlayUri = null;
+  cachedOverlayMimeType = null;
+  cachedOverlayUpdatedAt = 0;
+};
+
+export const ensureMaestroAvatarUris = async (): Promise<EnsuredAvatarResult> => {
+  const asset = await getMaestroProfileImageDB();
+  if (!asset?.dataUrl) return NULL_RESULT;
+
+  const mimeType = asset.mimeType || 'image/png';
+
+  // --- Ensure raw URI (for image generation) ---
+  let rawUri = cachedRawUri;
+  let rawMimeType = cachedRawMimeType;
+
+  const rawAge = cachedRawUpdatedAt > 0 ? Date.now() - cachedRawUpdatedAt : Number.POSITIVE_INFINITY;
+  if (!rawUri || rawAge > MAESTRO_URI_REFRESH_MS) {
+    // Check if the stored URI is still valid
+    let needsUpload = true;
+    if (asset.uri) {
+      try {
+        const statuses = await checkFileStatuses([asset.uri]);
+        const st = statuses[asset.uri];
+        if (st && !st.deleted && st.active) {
+          rawUri = asset.uri;
+          rawMimeType = mimeType;
+          needsUpload = false;
+        }
+      } catch { /* assume needs upload */ }
+    }
+
+    if (needsUpload) {
+      const uploaded = await uploadMediaToFiles(asset.dataUrl, mimeType, 'maestro-avatar');
+      rawUri = uploaded.uri;
+      rawMimeType = uploaded.mimeType || mimeType;
+      await setMaestroProfileImageDB({
+        dataUrl: asset.dataUrl,
+        mimeType: rawMimeType,
+        uri: rawUri,
+        updatedAt: Date.now(),
+      });
+      try {
+        window.dispatchEvent(new CustomEvent('maestro-avatar-updated', {
+          detail: { dataUrl: asset.dataUrl, mimeType: rawMimeType, uri: rawUri },
+        }));
+      } catch { /* ignore */ }
+    }
+
+    cachedRawUri = rawUri;
+    cachedRawMimeType = rawMimeType;
+    cachedRawUpdatedAt = Date.now();
+  }
+
+  // --- Ensure overlay URI (for chat LLM context) ---
+  let overlayUri = cachedOverlayUri;
+  let overlayMimeType = cachedOverlayMimeType;
+
+  const overlayAge = cachedOverlayUpdatedAt > 0 ? Date.now() - cachedOverlayUpdatedAt : Number.POSITIVE_INFINITY;
+  if (!overlayUri || overlayAge > MAESTRO_URI_REFRESH_MS) {
+    const overlay = await createAvatarWithOverlay(asset.dataUrl);
+    const uploaded = await uploadMediaToFiles(overlay.dataUrl, overlay.mimeType, 'maestro-avatar-overlay');
+    overlayUri = uploaded.uri;
+    overlayMimeType = uploaded.mimeType || overlay.mimeType;
+
+    cachedOverlayUri = overlayUri;
+    cachedOverlayMimeType = overlayMimeType;
+    cachedOverlayUpdatedAt = Date.now();
+  }
+
+  return { rawUri, rawMimeType, overlayUri, overlayMimeType };
+};

--- a/src/features/chat/services/chatHistory.ts
+++ b/src/features/chat/services/chatHistory.ts
@@ -264,10 +264,10 @@ export const setChatMetaDB = async (pairId: string, meta: ChatMeta | null): Prom
   });
 };
 
-type DerivedHistoryItem = { role: 'user' | 'assistant'; text?: string; rawAssistantResponse?: string; imageFileUri?: string; imageMimeType?: string; chatSummary?: string };
+type DerivedHistoryItem = { role: 'user' | 'assistant'; text?: string; rawAssistantResponse?: string; imageFileUri?: string; imageMimeType?: string; chatSummary?: string; avatarFileUri?: string; avatarMimeType?: string };
 
-export const deriveHistoryForApi = (fullHistory: ChatMessage[], opts?: { roles?: Array<'user' | 'assistant' | 'system'>; maxMessages?: number; maxMediaToKeep?: number; contextSummary?: string; globalProfileText?: string; placeholderLatestUserMessage?: string; }) => {
-    const { roles = ['user','assistant'], maxMessages, maxMediaToKeep = MAX_MEDIA_TO_KEEP, contextSummary, globalProfileText, placeholderLatestUserMessage } = opts || {};
+export const deriveHistoryForApi = (fullHistory: ChatMessage[], opts?: { roles?: Array<'user' | 'assistant' | 'system'>; maxMessages?: number; maxMediaToKeep?: number; contextSummary?: string; globalProfileText?: string; placeholderLatestUserMessage?: string; avatarOverlayFileUri?: string; avatarOverlayMimeType?: string; }) => {
+    const { roles = ['user','assistant'], maxMessages, maxMediaToKeep = MAX_MEDIA_TO_KEEP, contextSummary, globalProfileText, placeholderLatestUserMessage, avatarOverlayFileUri, avatarOverlayMimeType } = opts || {};
     const roleSet = new Set(roles);
     
     // 1. Filter relevant messages
@@ -329,6 +329,12 @@ export const deriveHistoryForApi = (fullHistory: ChatMessage[], opts?: { roles?:
       } else {
           history.unshift({ role: 'user', text: prefaceText });
       }
+    }
+
+    // 6b. Attach avatar overlay to the context message (first user message)
+    if (avatarOverlayFileUri && avatarOverlayMimeType && history.length > 0 && history[0].role === 'user') {
+      history[0].avatarFileUri = avatarOverlayFileUri;
+      history[0].avatarMimeType = avatarOverlayMimeType;
     }
 
     // 7. Append placeholder latest message if provided (e.g. for Image Gen context)

--- a/src/features/vision/index.ts
+++ b/src/features/vision/index.ts
@@ -13,9 +13,10 @@
 export { processMediaForUpload } from './services/mediaOptimizationService';
 
 // Utils
-export { 
+export {
   getFacingModeFromLabel,
   createKeyframeFromVideoDataUrl,
+  createAvatarWithOverlay,
 } from './utils/mediaUtils';
 
 // Hooks


### PR DESCRIPTION
Ensures avatar uri exist for avatar for the payload, create second version with text overlay (this is you, maestro), attach in with the global profile (as user message) to start of chat. Keep the existing behavior where the raw avatar url is added to image generation as user turn.