### PR TITLE
feat: ui style refactor paper.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,76 +4,64 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Gemini Language Tutor</title> 
+    <title>Gemini Language Tutor</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📚</text></svg>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Architects+Daughter&family=Caveat:wght@400;600;700&family=Patrick+Hand&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-      /* Custom scrollbar for webkit browsers */
-      ::-webkit-scrollbar { width: 8px; height: 8px; }
-      ::-webkit-scrollbar-track { background: #f1f1f1; border-radius: 10px; }
-      ::-webkit-scrollbar-thumb { background: #c7c7c7; border-radius: 10px; }
-      ::-webkit-scrollbar-thumb:hover { background: #a3a3a3; }
-
-      /* Splash screen styles */
-      #splash-screen {
-        position: fixed;
-        z-index: 9999;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: #f8fafc; /* slate-50 */
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        transition: opacity 0.5s ease-in-out;
-        opacity: 1;
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sketch: ['"Caveat"', 'cursive'],
+              hand: ['"Patrick Hand"', 'cursive'],
+              architect: ['"Architects Daughter"', 'cursive'],
+            },
+            colors: {
+              border: 'hsl(var(--border))',
+              input: 'hsl(var(--input))',
+              ring: 'hsl(var(--ring))',
+              background: 'hsl(var(--background))',
+              foreground: 'hsl(var(--foreground))',
+              primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+              secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+              destructive: { DEFAULT: 'hsl(var(--destructive))', foreground: 'hsl(var(--destructive-foreground))' },
+              muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+              accent: { DEFAULT: 'hsl(var(--accent))', foreground: 'hsl(var(--accent-foreground))' },
+              popover: { DEFAULT: 'hsl(var(--popover))', foreground: 'hsl(var(--popover-foreground))' },
+              card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+              paper: 'hsl(var(--paper))',
+              'paper-dark': 'hsl(var(--paper-dark))',
+              pencil: 'hsl(var(--pencil))',
+              'pencil-light': 'hsl(var(--pencil-light))',
+              'sketch-shadow': 'hsl(var(--sketch-shadow))',
+              eraser: 'hsl(var(--eraser))',
+              watercolor: 'hsl(var(--watercolor))',
+              ink: 'hsl(var(--ink))',
+            },
+            borderRadius: {
+              sketchy: '255px 15px 225px 15px / 15px 225px 15px 255px',
+            },
+            keyframes: {
+              wobble: { '0%, 100%': { transform: 'rotate(-0.5deg)' }, '25%': { transform: 'rotate(0.3deg)' }, '50%': { transform: 'rotate(-0.2deg)' }, '75%': { transform: 'rotate(0.4deg)' } },
+              float: { '0%, 100%': { transform: 'translateY(0) rotate(0deg)' }, '33%': { transform: 'translateY(-3px) rotate(0.5deg)' }, '66%': { transform: 'translateY(1px) rotate(-0.3deg)' } },
+              'pencil-scribble': { '0%': { width: '0%' }, '100%': { width: '100%' } },
+              'fade-up': { '0%': { opacity: '0', transform: 'translateY(20px)' }, '100%': { opacity: '1', transform: 'translateY(0)' } },
+              'sketch-in': { '0%': { opacity: '0', transform: 'scale(0.9) rotate(-1deg)' }, '100%': { opacity: '1', transform: 'scale(1) rotate(0deg)' } },
+            },
+            animation: {
+              wobble: 'wobble 3s ease-in-out infinite',
+              float: 'float 4s ease-in-out infinite',
+              'pencil-scribble': 'pencil-scribble 1.5s ease-in-out',
+              'fade-up': 'fade-up 0.5s ease-out',
+              'sketch-in': 'sketch-in 0.4s ease-out',
+            },
+          },
+        },
       }
-      #splash-screen.fade-out { opacity: 0; pointer-events: none; }
-      .splash-content { text-align: center; animation: pulseFade 2.5s infinite ease-in-out; }
-      @keyframes pulseFade {
-          0%, 100% { opacity: 0.8; transform: scale(1); }
-          50% { opacity: 1; transform: scale(1.02); }
-      }
-
-      /* Utilities */
-      .scrollbar-hide::-webkit-scrollbar { display: none; }
-      .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
-      .no-scrollbar::-webkit-scrollbar { display: none; }
-      .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
-
-      /* Image placeholder spinner */
-      .image-placeholder-spinner {
-        border: 4px solid rgba(0, 0, 0, 0.1);
-        width: 36px;
-        height: 36px;
-        border-radius: 50%;
-        border-left-color: #09f;
-        animation: spin 1s ease infinite;
-      }
-      @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
-
-      .globe-bg {
-        background-image: url('https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Flag_map_of_the_world_%282009_version%29.svg/2000px-Flag_map_of_the_world_%282009_version%29.svg.png');
-        background-size: 200% auto;
-        background-position: 0% center;
-        animation: rotate-globe 120s linear infinite;
-        box-shadow: inset 0 0 30px 10px rgba(0,0,0,0.5), 0 0 25px -8px rgba(70, 130, 180, 0.6);
-        border-color: rgba(113, 168, 212, 0.4);
-      }
-      @keyframes rotate-globe { from { background-position: 0% center; } to { background-position: 200% center; } }
-
-      /* Base styles */
-      body {
-        margin: 0;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-          'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-          sans-serif;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-      }
-    </style>
+    </script>
     <script type="importmap">
     {
       "imports": {
@@ -86,11 +74,11 @@
     </script>
 <link rel="stylesheet" href="./src/app/index.css">
 </head>
-<body class="antialiased">
+<body class="antialiased bg-background text-foreground">
     <div id="splash-screen">
       <div class="splash-content">
         <div style="font-size: 5rem; line-height: 1; margin-bottom: 1rem;">📚</div>
-        <h1 style="font-size: 1.5rem; font-weight: bold; color: #334155;">Gemini Language Tutor</h1>
+        <h1 style="font-size: 1.8rem; font-weight: bold; color: #3d3228; font-family: 'Caveat', cursive;">Maestro Tutor</h1>
       </div>
     </div>
     <div id="root"></div>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -520,10 +520,10 @@ const App: React.FC = () => {
 
   if (isApiKeyLoading) {
     return (
-      <div className="flex h-screen w-full items-center justify-center bg-slate-50">
-        <div className="text-center">
-          <SmallSpinner className="w-8 h-8 text-gray-500 block mx-auto" />
-          <p className="mt-2 text-gray-600">Loading app...</p>
+      <div className="flex h-screen w-full items-center justify-center bg-background paper-texture">
+        <div className="text-center relative z-10">
+          <SmallSpinner className="w-8 h-8 text-pencil-light block mx-auto" />
+          <p className="mt-2 text-muted-foreground font-hand">Loading app...</p>
         </div>
       </div>
     );
@@ -531,17 +531,17 @@ const App: React.FC = () => {
 
   if (isLoadingHistory && settings.selectedLanguagePairId) {
     return (
-      <div className="flex h-screen w-full items-center justify-center bg-slate-50">
-        <div className="text-center">
-          <SmallSpinner className="w-8 h-8 text-gray-500 block mx-auto" />
-          <p className="mt-2 text-gray-600">{t('chat.loadingHistory')}</p>
+      <div className="flex h-screen w-full items-center justify-center bg-background paper-texture">
+        <div className="text-center relative z-10">
+          <SmallSpinner className="w-8 h-8 text-pencil-light block mx-auto" />
+          <p className="mt-2 text-muted-foreground font-hand">{t('chat.loadingHistory')}</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col min-h-screen antialiased text-gray-800 bg-gray-100">
+    <div className="flex flex-col min-h-screen antialiased text-foreground bg-background paper-texture">
       <Header
         onOpenApiKey={() => {
           setApiKeyError(null);
@@ -569,7 +569,7 @@ const App: React.FC = () => {
         }}
       />
       <div className="flex flex-1 overflow-hidden">
-        <main className="flex-1 flex flex-col bg-slate-50">
+        <main className="flex-1 flex flex-col bg-paper relative z-10">
           <ChatInterface
             onSendMessage={handleSendMessageInternalRef.current || handleSendMessageInternal}
             onDeleteMessage={handleDeleteMessage}

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -2,16 +2,147 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+/* ============================================================
+   SKETCH DESIGN SYSTEM - CSS Variables
+   ============================================================ */
+@layer base {
+  :root {
+    --background: 39 35% 93%;
+    --foreground: 25 15% 20%;
+
+    --card: 39 40% 96%;
+    --card-foreground: 25 15% 20%;
+
+    --popover: 39 40% 96%;
+    --popover-foreground: 25 15% 20%;
+
+    --primary: 25 20% 25%;
+    --primary-foreground: 39 35% 93%;
+
+    --secondary: 35 25% 85%;
+    --secondary-foreground: 25 15% 25%;
+
+    --muted: 35 20% 88%;
+    --muted-foreground: 25 10% 45%;
+
+    --accent: 18 60% 55%;
+    --accent-foreground: 39 35% 96%;
+
+    --destructive: 0 65% 50%;
+    --destructive-foreground: 39 35% 96%;
+
+    --border: 25 18% 70%;
+    --input: 25 18% 75%;
+    --ring: 25 20% 35%;
+
+    --radius: 0.5rem;
+
+    --paper: 39 35% 93%;
+    --paper-dark: 35 12% 85%;
+    --pencil: 25 15% 25%;
+    --pencil-light: 25 10% 55%;
+    --sketch-shadow: 25 15% 20%;
+    --eraser: 0 60% 65%;
+    --watercolor: 200 45% 55%;
+    --ink: 220 30% 20%;
+  }
+
+  * {
+    border-color: hsl(var(--border));
+  }
+
+  body {
+    margin: 0;
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-family: 'Patrick Hand', 'Caveat', cursive;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 }
 
-/* Voice badge micro-animations */
+/* ============================================================
+   PAPER TEXTURE OVERLAY
+   ============================================================ */
+.paper-texture {
+  position: relative;
+}
+.paper-texture::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.04'/%3E%3C/svg%3E");
+  background-size: 256px 256px;
+}
+
+/* ============================================================
+   SKETCHY BORDERS & DECORATIVE ELEMENTS
+   ============================================================ */
+.sketchy-border {
+  border: 2px solid hsl(var(--pencil));
+  border-radius: 255px 15px 225px 15px / 15px 225px 15px 255px;
+  position: relative;
+}
+
+.sketchy-border-thin {
+  border: 1.5px solid hsl(var(--pencil-light));
+  border-radius: 255px 15px 225px 15px / 15px 225px 15px 255px;
+}
+
+.sketchy-underline {
+  text-decoration: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 8'%3E%3Cpath d='M0,5 Q25,2 50,5 T100,5 T150,5 T200,5' fill='none' stroke='%23594a3a' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-position: bottom;
+  background-repeat: repeat-x;
+  background-size: 200px 8px;
+  padding-bottom: 6px;
+}
+
+.notebook-lines {
+  background-image: repeating-linear-gradient(
+    transparent,
+    transparent 31px,
+    hsl(var(--pencil-light) / 0.15) 31px,
+    hsl(var(--pencil-light) / 0.15) 32px
+  );
+  background-position-y: 8px;
+}
+
+.tape-effect {
+  position: relative;
+}
+.tape-effect::before {
+  content: '';
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%) rotate(-2deg);
+  width: 60px;
+  height: 24px;
+  background: hsl(45 60% 80% / 0.6);
+  border: 1px solid hsl(45 30% 60% / 0.4);
+  z-index: 10;
+  border-radius: 2px;
+}
+
+.torn-paper {
+  clip-path: polygon(
+    0% 2%, 3% 0%, 7% 3%, 11% 1%, 15% 2%, 19% 0%, 23% 2%, 27% 1%, 31% 3%, 35% 0%,
+    39% 2%, 43% 1%, 47% 3%, 51% 0%, 55% 2%, 59% 1%, 63% 0%, 67% 3%, 71% 1%, 75% 2%,
+    79% 0%, 83% 3%, 87% 1%, 91% 2%, 95% 0%, 100% 2%,
+    100% 98%, 97% 100%, 93% 97%, 89% 100%, 85% 98%, 81% 100%, 77% 97%, 73% 100%,
+    69% 98%, 65% 100%, 61% 97%, 57% 100%, 53% 98%, 49% 100%, 45% 97%, 41% 100%,
+    37% 98%, 33% 100%, 29% 97%, 25% 100%, 21% 98%, 17% 100%, 13% 97%, 9% 100%,
+    5% 98%, 0% 100%
+  );
+}
+
+/* ============================================================
+   VOICE / STATUS MICRO-ANIMATIONS (app-specific)
+   ============================================================ */
 @layer utilities {
   @keyframes voice-swap {
     0% { transform: scale(0.9); opacity: 0.0; }
@@ -63,10 +194,76 @@ body {
     animation:
       flag-wave-transform 3s ease-in-out infinite,
       flag-wave-clip 1.5s linear infinite;
-    /* Ensure shadows work with clip-path via filter on parent or handling carefully */
   }
 
   /* Half-moon overlays matching avatar size */
   .moon-left { clip-path: inset(0 50% 0 0 round 9999px); }
   .moon-right { clip-path: inset(0 0 0 50% round 9999px); }
 }
+
+/* ============================================================
+   SCROLLBAR - sketchy style
+   ============================================================ */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: #ece4d4; }
+::-webkit-scrollbar-thumb { background: #8a7e72; border-radius: 12px; }
+::-webkit-scrollbar-thumb:hover { background: #6b5e50; }
+
+/* ============================================================
+   SPLASH SCREEN
+   ============================================================ */
+#splash-screen {
+  position: fixed;
+  z-index: 9999;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #ece4d4;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.5s ease-in-out;
+  opacity: 1;
+}
+#splash-screen.fade-out { opacity: 0; pointer-events: none; }
+.splash-content { text-align: center; animation: pulseFade 2.5s infinite ease-in-out; }
+@keyframes pulseFade {
+  0%, 100% { opacity: 0.8; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.02); }
+}
+
+/* ============================================================
+   SCROLL UTILITIES
+   ============================================================ */
+.scrollbar-hide::-webkit-scrollbar { display: none; }
+.scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
+.no-scrollbar::-webkit-scrollbar { display: none; }
+.no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+
+/* ============================================================
+   IMAGE PLACEHOLDER SPINNER
+   ============================================================ */
+.image-placeholder-spinner {
+  border: 4px solid rgba(0, 0, 0, 0.1);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border-left-color: #c06a3a;
+  animation: spin 1s ease infinite;
+}
+@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+
+/* ============================================================
+   GLOBE BACKGROUND
+   ============================================================ */
+.globe-bg {
+  background-image: url('https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Flag_map_of_the_world_%282009_version%29.svg/2000px-Flag_map_of_the_world_%282009_version%29.svg.png');
+  background-size: 200% auto;
+  background-position: 0% center;
+  animation: rotate-globe 120s linear infinite;
+  box-shadow: inset 0 0 30px 10px rgba(0,0,0,0.5), 0 0 25px -8px rgba(89, 74, 58, 0.6);
+  border-color: rgba(89, 74, 58, 0.4);
+}
+@keyframes rotate-globe { from { background-position: 0% center; } to { background-position: 200% center; } }

--- a/src/features/chat/components/AudioPlayer.tsx
+++ b/src/features/chat/components/AudioPlayer.tsx
@@ -208,18 +208,18 @@ const AudioPlayer: React.FC<AudioPlayerProps> = React.memo(({ src, variant, comp
   const isPreview = variant === 'preview';
 
   const containerClasses = isUser
-    ? 'bg-blue-600/30'
+    ? 'bg-primary/30'
     : isPreview
-      ? 'bg-gray-100'
-      : 'bg-gray-100';
+      ? 'bg-secondary'
+      : 'bg-secondary';
 
   const playBtnClasses = isUser
     ? 'bg-white/20 hover:bg-white/30 text-white'
-    : 'bg-blue-500 hover:bg-blue-600 text-white';
+    : 'bg-accent hover:bg-accent/80 text-accent-foreground';
 
-  const barPlayedColor = isUser ? 'bg-white' : 'bg-blue-500';
-  const barUnplayedColor = isUser ? 'bg-white/35' : 'bg-blue-200';
-  const timeColor = isUser ? 'text-white/70' : 'text-gray-500';
+  const barPlayedColor = isUser ? 'bg-white' : 'bg-accent';
+  const barUnplayedColor = isUser ? 'bg-white/35' : 'bg-accent/30';
+  const timeColor = isUser ? 'text-white/70' : 'text-muted-foreground';
 
   const btnSize = compact ? 'w-8 h-8' : 'w-10 h-10';
   const iconScale = compact ? 'w-4 h-4' : 'w-5 h-5';

--- a/src/features/chat/components/BookmarkActions.tsx
+++ b/src/features/chat/components/BookmarkActions.tsx
@@ -130,7 +130,7 @@ const BookmarkActions: React.FC<BookmarkActionsProps> = ({ t, message, maxVisibl
       >
         +
       </button>
-      <div className="w-px h-4 bg-white/40 mx-1" aria-hidden />
+      <div className="w-px h-4 bg-primary-foreground/40 mx-1" aria-hidden />
       <button
         type="button"
         onClick={startEditing}

--- a/src/features/chat/components/ChatInterface.tsx
+++ b/src/features/chat/components/ChatInterface.tsx
@@ -502,7 +502,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
     }, [isSpeaking, stopSpeaking, currentTargetLangCode, currentNativeLangCode, speakText]);
 
   return (
-    <div className="flex flex-col h-full bg-slate-100">
+    <div className="flex flex-col h-full bg-background notebook-lines">
       <div 
         ref={scrollContainerRef}
         className="flex-grow overflow-y-auto p-4"
@@ -522,7 +522,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
         <div className="space-y-2">
        {bookmarkInfo.hasBookmark && hiddenCount > 0 && (
          <div
-           className="my-1 px-2 py-1 bg-slate-200 border border-slate-300 rounded flex items-center gap-2"
+           className="my-1 px-2 py-1 bg-secondary border border-border rounded-sketchy flex items-center gap-2"
            role="region"
            aria-label={t('chat.bookmark.hiddenHeaderAria') || 'Hidden messages above'}
            style={{
@@ -530,8 +530,8 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
              containerType: 'inline-size'
            }}
          >
-           <IconEyeOpen className="w-4 h-4 text-slate-600" />
-           <span className="text-slate-700" style={{ fontSize: '2.8cqw' }}>
+           <IconEyeOpen className="w-4 h-4 text-pencil-light" />
+           <span className="text-foreground" style={{ fontSize: '2.8cqw' }}>
              {bookmarkViewMode === 'above' && bookmarkChunkMeta
                ? translateOrFallback(
                    'chat.bookmark.showingAboveRange',
@@ -547,7 +547,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
            <div className="ml-auto flex items-center gap-2" style={{ fontSize: '2.8cqw' }}>
              {bookmarkViewMode === 'above' && bookmarkChunkMeta ? (
                <button
-                 className="px-2 py-1 rounded bg-white hover:bg-gray-100 text-slate-800 border border-slate-300 disabled:opacity-50"
+                 className="px-2 py-1 rounded-sketchy bg-card hover:bg-secondary text-foreground border border-border disabled:opacity-50"
                  onClick={() => {
                    if (bookmarkChunkMeta && bookmarkChunkMeta.chunkIndex < bookmarkChunkMeta.chunkCount - 1) {
                      setBookmarkAboveChunkIndex(prev => Math.min(prev + 1, bookmarkChunkMeta.chunkCount - 1));
@@ -568,7 +568,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
                </button>
              ) : (
                <button
-                 className="px-2 py-1 rounded bg-white hover:bg-gray-100 text-slate-800 border border-slate-300"
+                 className="px-2 py-1 rounded-sketchy bg-card hover:bg-secondary text-foreground border border-border"
                  onClick={() => {
                    if (hiddenCount > 0) {
                      setBookmarkViewMode('above');
@@ -628,7 +628,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
                    </div>
                  )}
                  <button
-                   className={`p-1 rounded-full bg-amber-500/80 text-white hover:bg-amber-500 shadow-sm border border-amber-600`}
+                   className={`p-1 rounded-full bg-accent/80 text-accent-foreground hover:bg-accent shadow-sm border border-accent`}
                    onClick={(e) => { e.stopPropagation(); setOpenBookmarkControlsForId(prev => prev === msg.id ? null : msg.id); }}
                    title={t('chat.bookmark.actionsToggleTitle') || 'Bookmark options'}
                    aria-expanded={openBookmarkControlsForId === msg.id}
@@ -665,7 +665,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
                >
                  {isAssistant && (msg.id === bookmarkedMessageId || bookmarkEligibleAssistantIds.has(msg.id)) && (
                    <button
-                     className={`p-2 rounded-full ${isSuggestionMode ? 'bg-gray-300 text-gray-800' : 'bg-amber-400 text-white'} shadow`}
+                     className={`p-2 rounded-full ${isSuggestionMode ? 'bg-secondary text-foreground' : 'bg-accent text-accent-foreground'} shadow`}
                      onPointerDown={(e) => { e.stopPropagation(); }}
                          onClick={(e) => { e.stopPropagation(); if (msg.id !== bookmarkedMessageId) { onBookmarkAt(msg.id); } }}
                          title={msg.id === bookmarkedMessageId ? (t('chat.bookmark.isHere') || 'Bookmark is here') : (t('chat.bookmark.setHere') || 'Set bookmark here')}
@@ -675,7 +675,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
                    </button>
                  )}
                  <button
-                   className={`p-2 rounded-full ${isSuggestionMode ? 'bg-gray-300 text-gray-800' : 'bg-red-500 text-white'} shadow`}
+                   className={`p-2 rounded-full ${isSuggestionMode ? 'bg-secondary text-foreground' : 'bg-eraser text-accent-foreground'} shadow`}
                    onPointerDown={(e) => { e.stopPropagation(); }}
                    onClick={(e) => { e.stopPropagation(); onDeleteMessage(msg.id); }}
                    title="Delete message"
@@ -713,13 +713,13 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
         })}
         {latestGroundingChunks && latestGroundingChunks.length > 0 && (
           <div
-            className="mt-4 p-3 bg-gray-100 rounded-lg shadow"
+            className="mt-4 p-3 bg-secondary rounded-sketchy shadow sketchy-border-thin"
             style={{
               // @ts-ignore
               containerType: 'inline-size'
             }}
           >
-            <h4 className="font-semibold text-gray-600 mb-1" style={{ fontSize: '2.9cqw' }}>{t('chat.retrievedFromWeb')}</h4>
+            <h4 className="font-semibold text-muted-foreground mb-1 font-sketch" style={{ fontSize: '2.9cqw' }}>{t('chat.retrievedFromWeb')}</h4>
             <ul className="space-y-1">
               {latestGroundingChunks.map((chunk, index) => (
                 (chunk.web || chunk.retrievedContext) && (
@@ -728,7 +728,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
                       href={(chunk.web?.uri || chunk.retrievedContext?.uri)!}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-blue-500 hover:underline truncate block"
+                      className="text-watercolor hover:underline truncate block"
                       style={{ fontSize: '2.8cqw' }}
                       title={(chunk.web?.title || chunk.retrievedContext?.title || chunk.web?.uri || chunk.retrievedContext?.uri)!}
                     >
@@ -744,7 +744,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
 
        {bookmarkInfo.hasBookmark && bookmarkViewMode === 'above' && (
          <div
-           className="my-1 px-2 py-1 bg-slate-200 border border-slate-300 rounded flex items-center gap-2"
+           className="my-1 px-2 py-1 bg-secondary border border-border rounded-sketchy flex items-center gap-2"
            role="region"
            aria-label={t('chat.bookmark.hiddenBelowHeaderAria') || 'Hidden messages below'}
            style={{
@@ -752,8 +752,8 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
              containerType: 'inline-size'
            }}
          >
-           <IconEyeOpen className="w-4 h-4 text-slate-600" />
-           <span className="text-slate-700" style={{ fontSize: '2.8cqw' }}>
+           <IconEyeOpen className="w-4 h-4 text-pencil-light" />
+           <span className="text-foreground" style={{ fontSize: '2.8cqw' }}>
              {bookmarkChunkMeta
                ? translateOrFallback(
                    'chat.bookmark.showingAboveRange',
@@ -768,7 +768,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
            <div className="ml-auto flex items-center gap-2" style={{ fontSize: '2.8cqw' }}>
              {bookmarkChunkMeta && bookmarkChunkMeta.chunkIndex > 0 && (
                <button
-                 className="px-2 py-1 rounded bg-white hover:bg-gray-100 text-slate-800 border border-slate-300"
+                 className="px-2 py-1 rounded-sketchy bg-card hover:bg-secondary text-foreground border border-border"
                  onClick={() => setBookmarkAboveChunkIndex(prev => Math.max(prev - 1, 0))}
                  title={translateOrFallback(
                    'chat.bookmark.showPreviousChunk',
@@ -784,7 +784,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
                </button>
              )}
              <button
-               className="px-2 py-1 rounded bg-white hover:bg-gray-100 text-slate-800 border border-slate-300"
+               className="px-2 py-1 rounded bg-card hover:bg-secondary text-foreground border border-border"
                onClick={() => setBookmarkViewMode('below')}
                title={translateOrFallback('chat.bookmark.returnToRecent', 'Back to messages below')}
              >
@@ -797,7 +797,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
         {/* Note: Input area is always rendered now, but modes switch inside */}
         <div className="flex flex-col items-end mt-2">
             <div
-                className={`transition-colors duration-300 rounded-xl p-3 shadow-lg w-full max-w-2xl ${isSuggestionMode ? 'bg-gray-200 text-gray-700' : 'bg-blue-500 text-white'} relative`}
+                className={`transition-colors duration-300 rounded-sketchy p-3 shadow-lg w-full max-w-2xl sketchy-border ${isSuggestionMode ? 'bg-secondary text-foreground' : 'bg-accent text-accent-foreground'} relative`}
                 style={{
                 // @ts-ignore
                 containerType: 'inline-size'

--- a/src/features/chat/components/ChatMessageBubble.tsx
+++ b/src/features/chat/components/ChatMessageBubble.tsx
@@ -608,8 +608,8 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
   if (message.thinking && !message.isGeneratingImage) {
     return (
       <div className="flex justify-start mb-3 animate-pulse">
-        <div className="bg-gray-200 rounded-lg p-3 max-w-xl">
-          <p className="text-sm text-gray-700">{t('chat.thinking')}</p>
+        <div className="bg-secondary rounded-sketchy p-3 max-w-xl sketchy-border-thin">
+          <p className="text-sm text-muted-foreground font-hand">{t('chat.thinking')}</p>
         </div>
       </div>
     );
@@ -620,22 +620,22 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
   const sanitizedUserText = message.text ? message.text.replace(/\*/g, '') : '';
   const isUserLineSpeaking = isUser && sanitizedUserText && speakingUtteranceText === sanitizedUserText;
 
-  let bubbleWrapperClasses = "shadow relative overflow-hidden rounded-lg transition-all duration-300 ease-in-out";
+  let bubbleWrapperClasses = "shadow relative overflow-hidden rounded-sketchy transition-all duration-300 ease-in-out";
    if (applyFocusedImageStyles) {
-      bubbleWrapperClasses += " w-full"; 
-      if (!isImageSuccessfullyDisplayed && !message.isGeneratingImage && !isFileSuccessfullyDisplayed && !isVideoSuccessfullyDisplayed) { 
-           bubbleWrapperClasses += " p-3"; 
-           if (isUser) bubbleWrapperClasses += " bg-blue-500 bg-opacity-90 text-white";
-           else if (isError) bubbleWrapperClasses += " bg-red-100 bg-opacity-90 text-red-700";
-           else if (isStatus) bubbleWrapperClasses += " bg-yellow-100 bg-opacity-90 text-yellow-700";
-           else bubbleWrapperClasses += " bg-white bg-opacity-90 text-gray-800";
+      bubbleWrapperClasses += " w-full";
+      if (!isImageSuccessfullyDisplayed && !message.isGeneratingImage && !isFileSuccessfullyDisplayed && !isVideoSuccessfullyDisplayed) {
+           bubbleWrapperClasses += " p-3";
+           if (isUser) bubbleWrapperClasses += " bg-primary bg-opacity-90 text-primary-foreground";
+           else if (isError) bubbleWrapperClasses += " bg-destructive/10 bg-opacity-90 text-destructive";
+           else if (isStatus) bubbleWrapperClasses += " bg-accent/10 bg-opacity-90 text-accent";
+           else bubbleWrapperClasses += " bg-card bg-opacity-90 text-foreground";
       }
-  } else { 
+  } else {
       bubbleWrapperClasses += " p-3 max-w-[90%] sm:max-w-[80%] md:max-w-[70%] lg:max-w-[65%]";
-      if (isUser) bubbleWrapperClasses += " bg-blue-500 bg-opacity-90 text-white";
-      else if (isError) bubbleWrapperClasses += " bg-red-100 bg-opacity-90 text-red-700";
-      else if (isStatus) bubbleWrapperClasses += " bg-yellow-100 bg-opacity-90 text-yellow-700";
-      else bubbleWrapperClasses += " bg-white bg-opacity-90 text-gray-800";
+      if (isUser) bubbleWrapperClasses += " bg-primary bg-opacity-90 text-primary-foreground";
+      else if (isError) bubbleWrapperClasses += " bg-destructive/10 bg-opacity-90 text-destructive";
+      else if (isStatus) bubbleWrapperClasses += " bg-accent/10 bg-opacity-90 text-accent";
+      else bubbleWrapperClasses += " bg-card bg-opacity-90 text-foreground sketchy-border-thin";
   }
 
   const imageContainerBaseClasses = "relative rounded-lg group transition-all duration-300 ease-in-out";
@@ -649,7 +649,7 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
           imageContainerAspectClasses = "aspect-square"; 
       } else if (isImageSuccessfullyDisplayed || isVideoSuccessfullyDisplayed) {
           if (isAnnotationActive) {
-              imageContainerAspectClasses = "bg-gray-800"; 
+              imageContainerAspectClasses = "bg-primary"; 
               imageContainerFlexCenteringClasses = ""; 
           } else {
               imageContainerAspectClasses = "";
@@ -661,7 +661,7 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
   }
   
   const imageContainerDynamicBg = message.isGeneratingImage ? 
-      (applyFocusedImageStyles ? (isUser ? 'bg-blue-600/40' : 'bg-slate-700/50') : (isUser ? 'bg-blue-400/30' : 'bg-gray-200/50')) 
+      (applyFocusedImageStyles ? (isUser ? 'bg-primary/40' : 'bg-pencil/50') : (isUser ? 'bg-primary/30' : 'bg-secondary/50')) 
       : '';
 
   const imageContainerStyle: React.CSSProperties = {};
@@ -711,11 +711,11 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
                               onError={() => setLoadingAnimationError(true)}
                             />
                           ) : (
-                            <SmallSpinner className="w-full h-full text-slate-100" />
+                            <SmallSpinner className="w-full h-full text-primary-foreground" />
                           )}
                         </div>
                         {remainingTimeDisplay && (
-                          <p className={`mt-1 text-right text-xs px-1.5 py-0.5 rounded ${applyFocusedImageStyles ? 'text-slate-200 bg-slate-800/60' : 'text-gray-700 bg-gray-100/70'}`}>
+                          <p className={`mt-1 text-right text-xs px-1.5 py-0.5 rounded ${applyFocusedImageStyles ? 'text-primary-foreground/70 bg-primary/60' : 'text-muted-foreground bg-secondary/70'}`}>
                             {remainingTimeDisplay}
                           </p>
                         )}
@@ -842,7 +842,7 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
                             >
                               <button
                                 onClick={handleSaveAnnotation}
-                                className="p-2 bg-white text-black rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-black/50 focus:ring-white transition-colors"
+                                className="p-2 bg-card text-foreground rounded-full hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-black/50 focus:ring-card transition-colors"
                                 title={t('chat.annotateModal.saveAndAttach')}
                                 aria-label={t('chat.annotateModal.saveAndAttach')}
                               >
@@ -909,10 +909,10 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
                       </div>
                   )}
                   {isFileSuccessfullyDisplayed && (
-                      <div className={`p-4 flex flex-col items-center justify-center text-center rounded-lg h-full ${isUser ? 'bg-blue-400' : 'bg-gray-200'}`}>
-                          <IconPaperclip className={`w-10 h-10 ${isUser ? 'text-blue-100' : 'text-gray-500'}`} />
-                          <p className={`mt-2 text-xs font-mono break-all ${isUser ? 'text-white' : 'text-gray-700'}`}>{message.imageMimeType}</p>
-                          <p className={`mt-1 text-xs ${isUser ? 'text-blue-200' : 'text-gray-500'}`}>{t('chat.fileAttachment')}</p>
+                      <div className={`p-4 flex flex-col items-center justify-center text-center rounded-lg h-full ${isUser ? 'bg-primary/80' : 'bg-secondary'}`}>
+                          <IconPaperclip className={`w-10 h-10 ${isUser ? 'text-primary-foreground/70' : 'text-muted-foreground'}`} />
+                          <p className={`mt-2 text-xs font-mono break-all ${isUser ? 'text-primary-foreground' : 'text-foreground'}`}>{message.imageMimeType}</p>
+                          <p className={`mt-1 text-xs ${isUser ? 'text-primary-foreground/70' : 'text-muted-foreground'}`}>{t('chat.fileAttachment')}</p>
                       </div>
                   )}
                   {isPdfSuccessfullyDisplayed && (
@@ -946,7 +946,7 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
           
           {message.imageGenError && !message.isGeneratingImage && (
                <div className={`flex flex-col items-center justify-center p-2 rounded-lg 
-                  ${applyFocusedImageStyles ? 'absolute inset-0 bg-black/60 z-20' : `my-2 ${isUser ? 'bg-blue-400/60' : 'bg-gray-300/60'}`}
+                  ${applyFocusedImageStyles ? 'absolute inset-0 bg-black/60 z-20' : `my-2 ${isUser ? 'bg-primary/60' : 'bg-secondary/60'}`}
                `}>
                   <IconXMark className="w-8 h-8 text-red-300 mb-1"/>
                   <p className={`text-xs text-center ${applyFocusedImageStyles ? 'text-red-200' : 'text-red-700'}`}>
@@ -1025,7 +1025,7 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
                              className={`font-semibold whitespace-pre-wrap cursor-pointer transition-colors rounded-sm px-1 -mx-1 ${
                                  applyFocusedImageStyles
                                  ? (isCurrentLineSpeaking ? 'bg-sky-400 text-sky-900' : 'hover:text-sky-200 text-white')
-                                 : (isCurrentLineSpeaking ? 'bg-sky-100 text-sky-800' : 'hover:text-blue-600 text-gray-800')
+                                 : (isCurrentLineSpeaking ? 'bg-sky-100 text-sky-800' : 'hover:text-accent text-foreground')
                              }`}
                              style={{ fontSize: '4cqw', lineHeight: 1.3 }}
                              onPointerDown={handleLinePointerDown}
@@ -1074,8 +1074,8 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
                        {pair.native && (
                         <p className={`italic mt-0.5 whitespace-pre-wrap pl-2 border-l-2 rounded-sm px-1 -mx-1 ${
                              applyFocusedImageStyles
-                             ? (isCurrentLineSpeaking ? 'bg-slate-500 text-slate-100' : 'text-gray-200 border-gray-400')
-                             : (isCurrentLineSpeaking ? 'bg-slate-200 text-slate-800' : 'text-gray-500 border-gray-300')
+                             ? (isCurrentLineSpeaking ? 'bg-primary/60 text-primary-foreground/80' : 'text-primary-foreground/50 border-primary-foreground/30')
+                             : (isCurrentLineSpeaking ? 'bg-secondary text-foreground' : 'text-muted-foreground border-border')
                          }`} style={{ fontSize: '3.55cqw', lineHeight: 1.3 }}
                          onPointerDown={handleLinePointerDown}
                          onPointerUp={(e) => {
@@ -1114,7 +1114,7 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
                              className={`whitespace-pre-wrap cursor-pointer transition-colors rounded-sm px-1 -mx-1 ${
                                  applyFocusedImageStyles
                                  ? (isCurrentlySpeakingRaw ? 'bg-sky-400 text-sky-900' : 'hover:text-sky-200 text-white')
-                                 : (isCurrentlySpeakingRaw ? 'bg-sky-100 text-sky-800' : 'hover:text-blue-600 text-gray-800')
+                                 : (isCurrentlySpeakingRaw ? 'bg-sky-100 text-sky-800' : 'hover:text-accent text-foreground')
                              }`} style={{ fontSize: '4cqw', lineHeight: 1.3 }}
                              onPointerDown={handleLinePointerDown}
                              onPointerUp={(e) => handleLinePointerUp(e, message.rawAssistantResponse!, currentTargetLangCode)}
@@ -1146,7 +1146,7 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
                      </p>
                    )}
                    {isAssistant && !message.translations?.length && !message.rawAssistantResponse && !message.imageUrl && !message.isGeneratingImage && message.text && (
-                     <p className={`whitespace-pre-wrap ${applyFocusedImageStyles ? 'text-white' : 'text-gray-800'}`} style={{ fontSize: '3.6cqw', lineHeight: 1.35 }}>{message.text}</p>
+                     <p className={`whitespace-pre-wrap ${applyFocusedImageStyles ? 'text-white' : 'text-foreground'}`} style={{ fontSize: '3.6cqw', lineHeight: 1.35 }}>{message.text}</p>
                    )}
                </>
              )}

--- a/src/features/chat/components/InputArea.tsx
+++ b/src/features/chat/components/InputArea.tsx
@@ -593,11 +593,11 @@ const InputArea: React.FC<InputAreaProps> = ({
   };
 
   const containerClass = isSuggestionMode
-    ? 'bg-white text-gray-800 shadow-sm ring-1 ring-gray-300 focus-within:ring-2 focus-within:ring-gray-400'
-    : 'bg-blue-400 text-white shadow-sm ring-1 ring-blue-300 focus-within:ring-2 focus-within:ring-white/80';
+    ? 'bg-card text-foreground shadow-sm ring-1 ring-border focus-within:ring-2 focus-within:ring-pencil-light'
+    : 'bg-accent text-accent-foreground shadow-sm ring-1 ring-accent focus-within:ring-2 focus-within:ring-primary-foreground/80';
 
-  const sendButtonStyle = isSuggestionMode ? 'bg-gray-700 text-white hover:bg-gray-600 focus:ring-gray-400' : 'bg-white text-blue-600 hover:bg-blue-100 focus:ring-blue-200';
-  const iconButtonStyle = isSuggestionMode ? 'text-gray-500 hover:text-gray-900 hover:bg-gray-100' : 'text-blue-100 hover:text-white hover:bg-white/20';
+  const sendButtonStyle = isSuggestionMode ? 'bg-primary text-primary-foreground hover:bg-primary/80 focus:ring-ring' : 'bg-card text-accent hover:bg-secondary focus:ring-accent';
+  const iconButtonStyle = isSuggestionMode ? 'text-muted-foreground hover:text-foreground hover:bg-secondary' : 'text-accent-foreground/70 hover:text-accent-foreground hover:bg-white/20';
 
   const handlePaperclipClick = () => {
     if (!paperclipOpenTokenRef.current) {
@@ -870,9 +870,9 @@ const InputArea: React.FC<InputAreaProps> = ({
             </div>
           )}
 
-          {sttError && <p className={`p-1 rounded mt-1 ${isSuggestionMode ? 'text-red-800 bg-red-200/50' : 'text-red-200 bg-red-900/50'}`} style={{ fontSize: '2.8cqw' }} role="alert">{t('chat.error.sttError', {error: sttError})}</p>}
-          {autoCaptureError && <p className={`p-1 rounded mt-1 ${isSuggestionMode ? 'text-red-800 bg-red-200/50' : 'text-red-200 bg-red-900/50'}`} style={{ fontSize: '2.8cqw' }} role="alert">{t('chat.error.autoCaptureCameraError', {error: autoCaptureError})}</p>}
-          {snapshotUserError && <p className={`p-1 rounded mt-1 ${isSuggestionMode ? 'text-orange-800 bg-orange-200/50' : 'text-orange-200 bg-orange-900/50'}`} style={{ fontSize: '2.8cqw' }} role="alert">{t('chat.error.snapshotUserError', {error: snapshotUserError})}</p>}
+          {sttError && <p className={`p-1 rounded mt-1 ${isSuggestionMode ? 'text-destructive bg-destructive/10' : 'text-red-200 bg-red-900/50'}`} style={{ fontSize: '2.8cqw' }} role="alert">{t('chat.error.sttError', {error: sttError})}</p>}
+          {autoCaptureError && <p className={`p-1 rounded mt-1 ${isSuggestionMode ? 'text-destructive bg-destructive/10' : 'text-red-200 bg-red-900/50'}`} style={{ fontSize: '2.8cqw' }} role="alert">{t('chat.error.autoCaptureCameraError', {error: autoCaptureError})}</p>}
+          {snapshotUserError && <p className={`p-1 rounded mt-1 ${isSuggestionMode ? 'text-accent bg-accent/10' : 'text-orange-200 bg-orange-900/50'}`} style={{ fontSize: '2.8cqw' }} role="alert">{t('chat.error.snapshotUserError', {error: snapshotUserError})}</p>}
         </>
     </>
   );

--- a/src/features/chat/components/PdfViewer.tsx
+++ b/src/features/chat/components/PdfViewer.tsx
@@ -168,15 +168,15 @@ const PdfViewer: React.FC<PdfViewerProps> = React.memo(({ src, variant, compact 
 
   const isUser = variant === 'user';
 
-  const containerBg = isUser ? 'bg-blue-600/20' : 'bg-gray-50';
+  const containerBg = isUser ? 'bg-primary/20' : 'bg-secondary';
   const indicatorBg = 'bg-black/60 text-white';
-  const errorTextColor = isUser ? 'text-blue-100' : 'text-gray-500';
-  const iconColor = isUser ? 'text-blue-100' : 'text-gray-400';
+  const errorTextColor = isUser ? 'text-primary-foreground/70' : 'text-muted-foreground';
+  const iconColor = isUser ? 'text-primary-foreground/70' : 'text-muted-foreground';
 
   if (isLoading) {
     return (
       <div className={`flex flex-col items-center justify-center rounded-lg ${containerBg} ${compact ? 'h-24 w-full' : 'h-48 w-full'}`}>
-        <SmallSpinner className={`w-6 h-6 ${isUser ? 'text-white' : 'text-blue-500'}`} />
+        <SmallSpinner className={`w-6 h-6 ${isUser ? 'text-white' : 'text-accent'}`} />
         <p className={`mt-2 text-xs ${errorTextColor}`}>Loading PDF...</p>
       </div>
     );

--- a/src/features/chat/components/SuggestionsList.tsx
+++ b/src/features/chat/components/SuggestionsList.tsx
@@ -96,13 +96,13 @@ const SuggestionsList: React.FC<SuggestionsListProps> = ({
     >
         <div className="flex flex-wrap gap-2 justify-end">
             {isLoadingSuggestions && (
-              <span className="inline-block px-3 py-1.5 text-gray-500 italic" style={{ fontSize: '2.8cqw' }}>{t('chat.loadingSuggestions')}</span>
+              <span className="inline-block px-3 py-1.5 text-muted-foreground italic" style={{ fontSize: '2.8cqw' }}>{t('chat.loadingSuggestions')}</span>
             )}
             {!isLoadingSuggestions && replySuggestions.map((suggestion, index) => (
             <button
                 key={index}
                 onClick={(e) => { e.stopPropagation(); handleSuggestionBubbleClick(suggestion); }}
-                className={`inline-block px-3 py-1.5 rounded-full transition-colors text-gray-700 bg-gray-200 hover:bg-gray-300 ${doubleClickedSuggestionTarget === suggestion.target ? 'focus:outline-none focus:ring-2 focus:ring-sky-400' : 'focus:outline-none focus:ring-2 focus:ring-blue-400'}`}
+                className={`inline-block px-3 py-1.5 rounded-full transition-colors text-foreground bg-secondary hover:bg-paper-dark sketchy-border-thin ${doubleClickedSuggestionTarget === suggestion.target ? 'focus:outline-none focus:ring-2 focus:ring-watercolor' : 'focus:outline-none focus:ring-2 focus:ring-accent'}`}
                 style={{ fontSize: '3.1cqw' }}
                 title={t('chat.suggestion.speak', { suggestion: suggestion.target })}
                 aria-label={t('chat.suggestion.ariaLabel', { suggestion: suggestion.target })}
@@ -115,18 +115,18 @@ const SuggestionsList: React.FC<SuggestionsListProps> = ({
                 <button
                     onClick={(e) => { e.stopPropagation(); onToggleSuggestionMode(); }}
                     className={`inline-flex items-center justify-center w-[34px] h-[34px] text-sm rounded-full transition-colors disabled:opacity-50
-                        ${isSuggestionMode 
-                            ? 'bg-sky-500 text-white animate-pulse' 
-                            : 'text-gray-700 bg-gray-200 hover:bg-gray-300'
+                        ${isSuggestionMode
+                            ? 'bg-accent text-accent-foreground animate-pulse'
+                            : 'text-foreground bg-secondary hover:bg-paper-dark'
                         }
-                        focus:outline-none focus:ring-2 focus:ring-blue-400`}
+                        focus:outline-none focus:ring-2 focus:ring-accent`}
                     style={{ fontSize: '3cqw' }}
                     title={t('chat.suggestion.toggleCreateMode')}
                     aria-label={t('chat.suggestion.toggleCreateMode')}
                     aria-pressed={isSuggestionMode}
                     disabled={isCreatingSuggestion}
                 >
-                    {isCreatingSuggestion ? <SmallSpinner className="w-5 h-5 text-sky-200" /> : <IconTranslate className="w-5 h-5" />}
+                    {isCreatingSuggestion ? <SmallSpinner className="w-5 h-5 text-accent-foreground/70" /> : <IconTranslate className="w-5 h-5" />}
                 </button>
             )}
         </div>

--- a/src/features/chat/components/TextScrollwheel.tsx
+++ b/src/features/chat/components/TextScrollwheel.tsx
@@ -171,7 +171,7 @@ const TextScrollwheel: React.FC<TextScrollwheelProps> = React.memo(({ translatio
                 className="text-center p-1 w-full opacity-0 select-none pointer-events-none"
               >
                 <p
-                  className="italic text-gray-300"
+                  className="italic text-white/40"
                   style={{ fontSize: '3.55cqw', lineHeight: 1.3 }}
                 >
                   \u00A0
@@ -188,7 +188,7 @@ const TextScrollwheel: React.FC<TextScrollwheelProps> = React.memo(({ translatio
                   onContextMenu={(e) => e.preventDefault()}
                 > 
                   <p 
-                    className={`${line.type === 'target' ? 'font-semibold text-white' : 'italic text-gray-300'} pointer-events-none`}
+                    className={`${line.type === 'target' ? 'font-semibold text-white' : 'italic text-white/50'} pointer-events-none`}
                     style={{
                       fontSize: line.type === 'target' ? '4cqw' : '3.55cqw',
                       lineHeight: 1.3
@@ -209,7 +209,7 @@ const TextScrollwheel: React.FC<TextScrollwheelProps> = React.memo(({ translatio
                 className="text-center p-1 w-full opacity-0 select-none pointer-events-none"
               >
                 <p
-                  className="italic text-gray-300"
+                  className="italic text-white/40"
                   style={{ fontSize: '3.55cqw', lineHeight: 1.3 }}
                 >
                   \u00A0

--- a/src/features/chat/components/input/AudioControls.tsx
+++ b/src/features/chat/components/input/AudioControls.tsx
@@ -240,7 +240,7 @@ const AudioControls: React.FC<AudioControlsProps> = ({
           onClick={handleOpenLanguageSelector}
           className={`flex flex-col items-center justify-center p-1 rounded-full transition-colors ${
             isSuggestionMode
-              ? 'hover:bg-gray-100'
+              ? 'hover:bg-secondary'
               : 'hover:bg-white/20'
           }`}
           title={t('chat.languageSelector.openGlobe')}
@@ -248,11 +248,11 @@ const AudioControls: React.FC<AudioControlsProps> = ({
         >
           <span className="flex items-center gap-0.5 leading-none" style={{ fontSize: '10px' }}>
             {nativeLanguageDef.flag}
-            {hasSharedFlag(nativeLanguageDef) && <span className={`text-[7px] font-bold ${isSuggestionMode ? 'text-gray-500' : 'text-blue-100'}`}>{nativeLanguageDef.shortCode}</span>}
+            {hasSharedFlag(nativeLanguageDef) && <span className={`text-[7px] font-bold ${isSuggestionMode ? 'text-muted-foreground' : 'text-accent-foreground/70'}`}>{nativeLanguageDef.shortCode}</span>}
           </span>
           <span className="flex items-center gap-0.5 leading-none" style={{ fontSize: '14px' }}>
             {targetLanguageDef.flag}
-            {hasSharedFlag(targetLanguageDef) && <span className={`text-[9px] font-bold ${isSuggestionMode ? 'text-gray-500' : 'text-blue-100'}`}>{targetLanguageDef.shortCode}</span>}
+            {hasSharedFlag(targetLanguageDef) && <span className={`text-[9px] font-bold ${isSuggestionMode ? 'text-muted-foreground' : 'text-accent-foreground/70'}`}>{targetLanguageDef.shortCode}</span>}
           </span>
         </button>
       )}
@@ -267,7 +267,7 @@ const AudioControls: React.FC<AudioControlsProps> = ({
           onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); }}
           style={{ WebkitTouchCallout: 'none' } as React.CSSProperties}
           className={`relative overflow-visible p-2 rounded-full transition-colors touch-manipulation select-none ${
-            isRecordingAudioNote ? 'bg-red-500 text-white ring-2 ring-red-300' : isListening ? 'bg-red-500/80 text-white' : (isSuggestionMode ? 'text-gray-500 hover:text-gray-900 hover:bg-gray-100' : 'text-blue-100 hover:text-white hover:bg-white/20')
+            isRecordingAudioNote ? 'bg-red-500 text-white ring-2 ring-red-300' : isListening ? 'bg-red-500/80 text-white' : (isSuggestionMode ? 'text-muted-foreground hover:text-foreground hover:bg-secondary' : 'text-accent-foreground/70 hover:text-accent-foreground hover:bg-white/20')
           } disabled:opacity-50`}
           title={getMicButtonTitle()}
           disabled={isSending || isSpeaking || isLanguageSelectionOpen}

--- a/src/features/chat/components/input/CameraControls.tsx
+++ b/src/features/chat/components/input/CameraControls.tsx
@@ -341,8 +341,8 @@ const CameraControls: React.FC<CameraControlsProps> = ({
 
   // Selector colors
   const selectorColors = isSuggestionMode
-    ? { bg: 'bg-gray-200/80', activeBg: 'bg-white', activeText: 'text-gray-800', inactiveText: 'text-gray-500', hoverBg: 'hover:bg-gray-300/80' }
-    : { bg: 'bg-blue-500/40', activeBg: 'bg-white', activeText: 'text-blue-600', inactiveText: 'text-blue-200', hoverBg: 'hover:bg-blue-400/60' };
+    ? { bg: 'bg-secondary/80', activeBg: 'bg-card', activeText: 'text-accent', inactiveText: 'text-muted-foreground', hoverBg: 'hover:bg-muted' }
+    : { bg: 'bg-accent/40', activeBg: 'bg-card', activeText: 'text-accent', inactiveText: 'text-accent-foreground/60', hoverBg: 'hover:bg-accent/60' };
 
   // Check if a specific action is highlighted (for visual feedback during touch drag)
   const isHighlighted = useCallback((action: string, deviceId?: string) => {

--- a/src/features/chat/components/input/LiveSessionControls.tsx
+++ b/src/features/chat/components/input/LiveSessionControls.tsx
@@ -31,8 +31,8 @@ const LiveSessionControls: React.FC<LiveSessionControlsProps> = ({
   const liveSessionButtonClasses = liveSessionActive
     ? 'bg-red-600/80 hover:bg-red-500 text-white'
     : (liveSessionErrored
-      ? 'bg-yellow-500/80 hover:bg-yellow-500 text-slate-900'
-      : (isSuggestionMode ? 'bg-gray-700/80 hover:bg-gray-800 text-white' : 'bg-black/60 hover:bg-black/80 text-white'));
+      ? 'bg-yellow-500/80 hover:bg-yellow-500 text-foreground'
+      : (isSuggestionMode ? 'bg-primary/80 hover:bg-primary text-primary-foreground' : 'bg-black/60 hover:bg-black/80 text-white'));
 
   const handleLiveSessionToggle = useCallback(() => {
     if (liveSessionActive) {

--- a/src/features/chat/components/input/MediaAttachments.tsx
+++ b/src/features/chat/components/input/MediaAttachments.tsx
@@ -231,7 +231,7 @@ const MediaAttachments: React.FC<MediaAttachmentsProps> = ({
   return (
     <div className="flex flex-wrap justify-center items-start gap-2 w-full">
       {attachedImageBase64 && (
-        <div className={`relative ${isTwoUp ? 'w-[calc(50%-0.25rem)] sm:w-48' : 'w-48'} min-w-0 ${isSuggestionMode ? 'bg-gray-300' : 'bg-blue-400'} p-1 rounded-md`}>
+        <div className={`relative ${isTwoUp ? 'w-[calc(50%-0.25rem)] sm:w-48' : 'w-48'} min-w-0 ${isSuggestionMode ? 'bg-secondary' : 'bg-accent/80'} p-1 rounded-md`}>
           {attachedImageMimeType?.startsWith('image/') ? (
             <div className="relative">
               <img src={attachedImageBase64} alt={t('chat.imagePreview.alt')} className="h-24 w-full object-cover rounded" />
@@ -299,9 +299,9 @@ const MediaAttachments: React.FC<MediaAttachmentsProps> = ({
               </button>
             </div>
           ) : (
-            <div className={`h-24 w-full flex flex-col items-center justify-center ${isSuggestionMode ? 'bg-gray-100' : 'bg-blue-300'} rounded`}>
-              <IconPaperclip className={`w-8 h-8 ${isSuggestionMode ? 'text-gray-500' : 'text-blue-100'}`} />
-              <span className={`text-xs mt-1 truncate max-w-full px-1 ${isSuggestionMode ? 'text-gray-600' : 'text-white'}`}>{attachedImageMimeType}</span>
+            <div className={`h-24 w-full flex flex-col items-center justify-center ${isSuggestionMode ? 'bg-muted' : 'bg-accent/60'} rounded`}>
+              <IconPaperclip className={`w-8 h-8 ${isSuggestionMode ? 'text-muted-foreground' : 'text-accent-foreground/70'}`} />
+              <span className={`text-xs mt-1 truncate max-w-full px-1 ${isSuggestionMode ? 'text-muted-foreground' : 'text-accent-foreground'}`}>{attachedImageMimeType}</span>
             </div>
           )}
           <div className="absolute -top-2 -right-2 flex items-center space-x-1">
@@ -313,7 +313,7 @@ const MediaAttachments: React.FC<MediaAttachmentsProps> = ({
       )}
 
       {showLiveFeed && (
-        <div className={`relative ${isTwoUp ? 'w-[calc(50%-0.25rem)] sm:w-48' : 'w-48'} min-w-0 ${isSuggestionMode ? 'bg-gray-300' : 'bg-blue-400'} p-1 rounded-md`}>
+        <div className={`relative ${isTwoUp ? 'w-[calc(50%-0.25rem)] sm:w-48' : 'w-48'} min-w-0 ${isSuggestionMode ? 'bg-secondary' : 'bg-accent/80'} p-1 rounded-md`}>
           <div className="relative group">
             <video
               ref={livePreviewVideoRef}
@@ -371,7 +371,7 @@ const MediaAttachments: React.FC<MediaAttachmentsProps> = ({
             )}
           </div>
           {liveSessionError && (
-            <div className={`mt-1 px-2 py-1 text-xs rounded ${isSuggestionMode ? 'bg-red-100 text-red-700' : 'bg-red-600/20 text-red-100'}`}>
+            <div className={`mt-1 px-2 py-1 text-xs rounded ${isSuggestionMode ? 'bg-destructive/10 text-destructive' : 'bg-red-600/20 text-red-100'}`}>
               {liveSessionError}
             </div>
           )}

--- a/src/features/diagnostics/components/DebugLogPanel.tsx
+++ b/src/features/diagnostics/components/DebugLogPanel.tsx
@@ -28,26 +28,26 @@ const DebugLogPanel: React.FC<DebugLogPanelProps> = ({ onClose }) => {
   };
 
   return (
-    <div className="fixed inset-y-0 right-0 w-full sm:w-[480px] bg-slate-900 shadow-2xl z-[100] flex flex-col border-l border-slate-700 font-mono text-sm">
+    <div className="fixed inset-y-0 right-0 w-full sm:w-[480px] bg-primary shadow-2xl z-[100] flex flex-col border-l border-border font-mono text-sm">
       {/* Header */}
       <div
-        className="flex items-center justify-between px-4 pb-3 bg-slate-800 border-b border-slate-700"
+        className="flex items-center justify-between px-4 pb-3 bg-primary/90 border-b border-border"
         style={{ paddingTop: 'calc(0.75rem + env(safe-area-inset-top))' }}
       >
-        <h2 className="text-slate-200 font-semibold flex items-center gap-2">
+        <h2 className="text-primary-foreground font-semibold flex items-center gap-2">
           <span className="text-green-400">➜</span> Traffic Log
         </h2>
         <div className="flex items-center gap-2">
           <button
             onClick={handleClear}
-            className="p-1.5 text-slate-400 hover:text-red-400 hover:bg-slate-700 rounded transition-colors"
+            className="p-1.5 text-muted-foreground hover:text-eraser hover:bg-primary/70 rounded transition-colors"
             title="Clear logs"
           >
             <IconTrash className="w-4 h-4" />
           </button>
           <button
             onClick={onClose}
-            className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded transition-colors"
+            className="p-1.5 text-muted-foreground hover:text-primary-foreground hover:bg-primary/70 rounded transition-colors"
             title="Close"
           >
             <IconXMark className="w-5 h-5" />
@@ -56,9 +56,9 @@ const DebugLogPanel: React.FC<DebugLogPanelProps> = ({ onClose }) => {
       </div>
 
       {/* Log List */}
-      <div className="flex-1 overflow-y-auto p-2 space-y-2 bg-slate-900">
+      <div className="flex-1 overflow-y-auto p-2 space-y-2 bg-primary">
         {logs.length === 0 && (
-          <div className="text-slate-500 text-center py-10 italic">
+          <div className="text-muted-foreground text-center py-10 italic">
             No traffic recorded yet.
           </div>
         )}
@@ -71,36 +71,36 @@ const DebugLogPanel: React.FC<DebugLogPanelProps> = ({ onClose }) => {
           return (
             <div
               key={log.id}
-              className={`rounded border ${isError ? 'border-red-800 bg-red-900/10' : 'border-slate-700 bg-slate-800/50'} overflow-hidden transition-colors`}
+              className={`rounded border ${isError ? 'border-red-800 bg-red-900/10' : 'border-border bg-primary/70'} overflow-hidden transition-colors`}
             >
               <div
                 className="px-3 py-2 cursor-pointer flex items-center justify-between hover:bg-white/5 select-none"
                 onClick={() => toggleExpand(log.id)}
               >
                 <div className="flex items-center gap-2 overflow-hidden">
-                  <span className={`text-xs ${isError ? 'text-red-400' : 'text-slate-500'}`}>{time}</span>
-                  <span className={`font-semibold truncate ${isError ? 'text-red-300' : 'text-blue-300'}`}>{log.type}</span>
-                  <span className="text-xs text-slate-500 truncate hidden sm:inline-block">- {log.model}</span>
+                  <span className={`text-xs ${isError ? 'text-red-400' : 'text-muted-foreground'}`}>{time}</span>
+                  <span className={`font-semibold truncate ${isError ? 'text-red-300' : 'text-watercolor'}`}>{log.type}</span>
+                  <span className="text-xs text-muted-foreground truncate hidden sm:inline-block">- {log.model}</span>
                 </div>
                 <div className="flex items-center gap-2 text-xs">
                   <span className={`${isError ? 'text-red-400' : 'text-green-400'}`}>{duration}</span>
-                  <span className="text-slate-600">{isExpanded ? '▲' : '▼'}</span>
+                  <span className="text-muted-foreground">{isExpanded ? '▲' : '▼'}</span>
                 </div>
               </div>
 
               {isExpanded && (
-                <div className="border-t border-slate-700/50">
+                <div className="border-t border-border/50">
                   {/* Request Section */}
-                  <div className="bg-slate-950/50 p-2">
-                    <div className="text-xs text-slate-400 uppercase font-bold mb-1 px-1">Request Payload</div>
-                    <pre className="text-xs text-slate-300 overflow-x-auto whitespace-pre-wrap break-all bg-black/20 p-2 rounded max-h-60 overflow-y-auto custom-scrollbar">
+                  <div className="bg-black/20 p-2">
+                    <div className="text-xs text-muted-foreground uppercase font-bold mb-1 px-1">Request Payload</div>
+                    <pre className="text-xs text-primary-foreground/70 overflow-x-auto whitespace-pre-wrap break-all bg-black/20 p-2 rounded max-h-60 overflow-y-auto custom-scrollbar">
                       {JSON.stringify(log.request, null, 2)}
                     </pre>
                   </div>
 
                   {/* Response Section */}
                   {(log.response || log.error) && (
-                    <div className="bg-slate-950/30 p-2 border-t border-slate-800/50">
+                    <div className="bg-black/10 p-2 border-t border-border/30">
                       <div className={`text-xs uppercase font-bold mb-1 px-1 ${isError ? 'text-red-400' : 'text-green-400'}`}>
                         {isError ? 'Error' : 'Response'}
                       </div>

--- a/src/features/session/components/ApiKeyGate.tsx
+++ b/src/features/session/components/ApiKeyGate.tsx
@@ -142,21 +142,21 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4">
-      <div className="w-full max-w-lg rounded-2xl bg-white shadow-xl border border-slate-200">
+      <div className="w-full max-w-lg rounded-2xl bg-card shadow-xl border border-border sketchy-border">
         <div className="flex items-start justify-between px-6 pt-6">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-50 text-blue-600">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-accent/15 text-accent">
               <IconShield className="h-5 w-5" />
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-slate-900">
+              <h2 className="text-lg font-semibold text-foreground font-sketch">
                 {isBillingHelp ? t('apiKeyGate.billingTitle') : t('apiKeyGate.title')}
               </h2>
-              <p className="text-sm text-slate-600">
+              <p className="text-sm text-muted-foreground">
                 {t('apiKeyGate.subtitle')}{' '}
                 <button
                   onClick={() => openExternalUrl(PRIVACY_POLICY_URL)}
-                  className="text-blue-600 hover:underline inline-flex items-center"
+                  className="text-accent hover:underline inline-flex items-center"
                 >
                   {t('apiKeyGate.privacyPolicy')}
                 </button>
@@ -166,7 +166,7 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
           {showHeaderClose && (
             <button
               onClick={handleHeaderClose}
-              className="text-slate-400 hover:text-slate-700"
+              className="text-muted-foreground hover:text-foreground"
               aria-label={headerCloseLabel}
             >
               <IconXMark className="h-5 w-5" />
@@ -177,8 +177,8 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
         <div className="px-6 py-4 space-y-4">
           {showInstructions ? (
             <div className="flex flex-col items-center gap-4">
-              <div className="relative w-full max-w-[360px] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-                <div className="aspect-[9/16] w-full bg-slate-100">
+              <div className="relative w-full max-w-[360px] overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+                <div className="aspect-[9/16] w-full bg-muted">
                   <img
                     src={currentInstruction}
                     alt={t('apiKeyGate.instructionStep', { step: instructionIndex + 1, total: totalInstructions })}
@@ -193,7 +193,7 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
                         type="button"
                         onClick={() => handleInstructionStep(-1)}
                         aria-label={t('apiKeyGate.previousInstruction')}
-                        className="pointer-events-auto rounded-full bg-white/90 p-2 text-slate-600 shadow hover:bg-white"
+                        className="pointer-events-auto rounded-full bg-card/90 p-2 text-muted-foreground shadow hover:bg-card"
                       >
                         <IconChevronLeft className="h-5 w-5" />
                       </button>
@@ -201,14 +201,14 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
                         type="button"
                         onClick={() => handleInstructionStep(1)}
                         aria-label={t('apiKeyGate.nextInstruction')}
-                        className="pointer-events-auto rounded-full bg-white/90 p-2 text-slate-600 shadow hover:bg-white"
+                        className="pointer-events-auto rounded-full bg-card/90 p-2 text-muted-foreground shadow hover:bg-card"
                       >
                         <IconChevronRight className="h-5 w-5" />
                       </button>
                     </div>
                     {!isBillingHelp && (
                       <>
-                        <div className="absolute bottom-3 left-1/2 -translate-x-1/2 rounded-full bg-white/90 px-3 py-1 shadow-sm">
+                        <div className="absolute bottom-3 left-1/2 -translate-x-1/2 rounded-full bg-card/90 px-3 py-1 shadow-sm">
                           <div className="flex items-center gap-1.5">
                             {INSTRUCTION_IMAGES.slice(0, REGULAR_INSTRUCTIONS_COUNT).map((_, index) => (
                               <button
@@ -216,12 +216,12 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
                                 type="button"
                                 aria-label={t('apiKeyGate.instructionStep', { step: index + 1, total: REGULAR_INSTRUCTIONS_COUNT })}
                                 onClick={() => handleInstructionJump(index)}
-                                className={`h-2 w-2 rounded-full ${index === instructionIndex ? 'bg-blue-600' : 'bg-slate-300'}`}
+                                className={`h-2 w-2 rounded-full ${index === instructionIndex ? 'bg-accent' : 'bg-border'}`}
                               />
                             ))}
                           </div>
                         </div>
-                        <div className="absolute right-3 top-3 rounded-full bg-white/90 px-2 py-1 text-xs text-slate-600 shadow-sm">
+                        <div className="absolute right-3 top-3 rounded-full bg-card/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
                           {instructionIndex + 1} / {REGULAR_INSTRUCTIONS_COUNT}
                         </div>
                       </>
@@ -232,15 +232,15 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
             </div>
           ) : (
             <>
-              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 space-y-2">
-                <div className="font-medium text-slate-800">{t('apiKeyGate.stepsTitle')}</div>
+              <div className="rounded-xl border border-border bg-muted p-4 text-sm text-foreground space-y-2">
+                <div className="font-medium text-foreground font-sketch">{t('apiKeyGate.stepsTitle')}</div>
                 <ol className="list-decimal pl-5 space-y-1">
                   <li>{t('apiKeyGate.stepOne')}</li>
                   <li>{t('apiKeyGate.stepTwo')}</li>
                 </ol>
                 <div className="flex flex-wrap items-center gap-2">
                   <button
-                    className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-white hover:bg-blue-700"
+                    className="inline-flex items-center gap-2 rounded-lg bg-accent px-3 py-2 text-accent-foreground hover:bg-accent/80"
                     onClick={() => openExternalUrl(AI_STUDIO_URL)}
                   >
                     {t('apiKeyGate.openAiStudio')}
@@ -253,14 +253,14 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
                       setIsAutoPlaying(true);
                     }}
                     aria-label={t('apiKeyGate.viewInstructions')}
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-600 hover:bg-slate-100"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border bg-card text-muted-foreground hover:bg-muted"
                   >
                     <IconQuestionMarkCircle className="h-5 w-5" />
                   </button>
                 </div>
               </div>
 
-              <label className="block text-sm font-medium text-slate-800">{t('apiKeyGate.keyLabel')}</label>
+              <label className="block text-sm font-medium text-foreground">{t('apiKeyGate.keyLabel')}</label>
               <div className="flex items-center gap-2">
                 <input
                   type={showKey ? 'text' : 'password'}
@@ -272,11 +272,11 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
                   }}
                   onClick={attemptAutoPasteFromClipboard}
                   placeholder={t('apiKeyGate.placeholder')}
-                  className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="flex-1 rounded-lg border border-border px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
                   autoFocus
                 />
                 <button
-                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-700 hover:bg-slate-100"
+                  className="rounded-lg border border-border px-3 py-2 text-sm text-foreground hover:bg-muted"
                   onClick={() => setShowKey(!showKey)}
                   type="button"
                 >
@@ -284,10 +284,10 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
                 </button>
               </div>
 
-              {error && <div className="text-sm text-red-600">{error}</div>}
+              {error && <div className="text-sm text-destructive">{error}</div>}
 
               {hasKey && (
-                <div className="rounded-lg bg-emerald-50 border border-emerald-200 p-3 text-sm text-emerald-800 flex items-center gap-2">
+                <div className="rounded-lg bg-green-50 border border-green-200 p-3 text-sm text-green-800 flex items-center gap-2">
                   <IconCheck className="h-4 w-4" />
                   {t('apiKeyGate.currentKeySaved', { maskedKey: maskedKey ? `(${maskedKey})` : '' }).trim()}
                 </div>
@@ -299,7 +299,7 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
         {!showInstructions && (
           <div className="flex items-center justify-between px-6 pb-6">
             <button
-              className="text-sm text-slate-500 hover:text-slate-700"
+              className="text-sm text-muted-foreground hover:text-foreground"
               onClick={onClear}
               disabled={!hasKey}
             >
@@ -309,7 +309,7 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
               {canClose && (
                 <button
                   onClick={onClose}
-                  className="rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100"
+                  className="rounded-lg border border-border px-4 py-2 text-sm text-foreground hover:bg-muted"
                 >
                   {t('apiKeyGate.cancel')}
                 </button>
@@ -323,7 +323,7 @@ const ApiKeyGate: React.FC<ApiKeyGateProps> = ({
                   }
                 }}
                 disabled={!canSave}
-                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:bg-accent/80 disabled:opacity-50"
               >
                 {isSaving ? t('apiKeyGate.saving') : t('apiKeyGate.saveKey')}
               </button>

--- a/src/features/session/components/CollapsedMaestroStatus.tsx
+++ b/src/features/session/components/CollapsedMaestroStatus.tsx
@@ -91,16 +91,16 @@ export const getStatusConfig = (
 
   switch (stage) {
     case 'speaking':
-      return { color: 'bg-blue-500', borderColor: 'border-blue-600', textColor: 'text-white' };
+      return { color: 'bg-accent', borderColor: 'border-accent', textColor: 'text-accent-foreground' };
     case 'typing':
-      return { color: 'bg-blue-400', borderColor: 'border-blue-500', textColor: 'text-white' };
+      return { color: 'bg-accent/80', borderColor: 'border-accent', textColor: 'text-accent-foreground' };
     case 'listening':
-      return { color: 'bg-green-500', borderColor: 'border-green-600', textColor: 'text-white' };
+      return { color: 'bg-green-600', borderColor: 'border-green-700', textColor: 'text-white' };
     case 'observing_high':
-      return { color: 'bg-amber-500', borderColor: 'border-amber-600', textColor: 'text-white' };
+      return { color: 'bg-amber-600', borderColor: 'border-amber-700', textColor: 'text-white' };
     case 'observing_low':
     case 'observing_medium':
-      return { color: 'bg-slate-200', borderColor: 'border-slate-300', textColor: 'text-slate-600' };
+      return { color: 'bg-secondary', borderColor: 'border-border', textColor: 'text-muted-foreground' };
     case 'idle':
     default: {
       const hasBusyTasks = activeUiTokens.length > 0 || isLive;
@@ -115,9 +115,9 @@ export const getStatusConfig = (
         }
       }
       if (hasBusyTasks) {
-        return { color: 'bg-indigo-100', borderColor: 'border-indigo-200', textColor: 'text-indigo-700' };
+        return { color: 'bg-watercolor/20', borderColor: 'border-watercolor/30', textColor: 'text-watercolor' };
       }
-      return { color: 'bg-slate-100', borderColor: 'border-slate-200', textColor: 'text-slate-500' };
+      return { color: 'bg-muted', borderColor: 'border-border', textColor: 'text-muted-foreground' };
     }
   }
 };

--- a/src/features/session/components/GlobalProfileSummary.tsx
+++ b/src/features/session/components/GlobalProfileSummary.tsx
@@ -34,7 +34,7 @@ const GlobalProfileSummary: React.FC<GlobalProfileSummaryProps> = ({ t: _t, mess
   
   return (
     <div
-      className="text-[11px] text-slate-700 whitespace-nowrap overflow-x-auto overflow-y-hidden flex-1 min-w-0 no-scrollbar"
+      className="text-[11px] text-muted-foreground whitespace-nowrap overflow-x-auto overflow-y-hidden flex-1 min-w-0 no-scrollbar"
       style={{ touchAction: 'pan-x', WebkitOverflowScrolling: 'touch' as any, msOverflowStyle: 'none' as any, scrollbarWidth: 'none' as any }}
       title={summary}
       tabIndex={0}

--- a/src/features/session/components/Header.tsx
+++ b/src/features/session/components/Header.tsx
@@ -211,7 +211,7 @@ const Header = forwardRef<HTMLDivElement, HeaderProps>(({ onOpenApiKey, hasApiKe
 
          <button
            onClick={toggleDebugLogs}
-           className="p-2 bg-slate-800/80 hover:bg-slate-700 text-slate-400 hover:text-white rounded-full shadow-sm backdrop-blur-sm transition-all"
+           className="p-2 bg-primary/80 hover:bg-primary text-muted-foreground hover:text-primary-foreground rounded-full shadow-sm backdrop-blur-sm transition-all"
            title="View Traffic Logs"
          >
            <IconTerminal className="w-4 h-4" />

--- a/src/features/session/components/LanguageScrollWheel.tsx
+++ b/src/features/session/components/LanguageScrollWheel.tsx
@@ -146,13 +146,13 @@ const LanguageScrollWheel: React.FC<LanguageScrollWheelProps> = ({ languages, se
 
     const scrollingBorderClass = isScrolling && variant
         ? variant === 'native'
-            ? 'ring-2 ring-sky-400 shadow-sky-400/30 shadow-md'
-            : 'ring-2 ring-green-400 shadow-green-400/30 shadow-md'
+            ? 'ring-2 ring-accent shadow-accent/30 shadow-md'
+            : 'ring-2 ring-green-500 shadow-green-500/30 shadow-md'
         : '';
 
     return (
         <div className={`flex-1 text-center relative min-w-[3rem] ${disabled ? 'opacity-50' : ''}`}>
-            {title && <p className="text-xs text-slate-400 mb-1 h-4">{title}</p>}
+            {title && <p className="text-xs text-muted-foreground mb-1 h-4">{title}</p>}
             <div className={`rounded-lg transition-all duration-150 ${scrollingBorderClass}`}>
                 <div 
                     ref={scrollContainerRef}
@@ -178,7 +178,7 @@ const LanguageScrollWheel: React.FC<LanguageScrollWheelProps> = ({ languages, se
                         >
                             <span className={`text-2xl font-semibold flex items-center gap-0.5 cursor-pointer transition-all duration-200 ${isSelected ? 'opacity-100 scale-125' : 'opacity-50 scale-100'}`}>
                                 {lang.flag}
-                                {showShortCode && <span className="text-[9px] text-slate-300 font-bold ml-0.5">{lang.shortCode}</span>}
+                                {showShortCode && <span className="text-[9px] text-primary-foreground/50 font-bold ml-0.5">{lang.shortCode}</span>}
                             </span>
                         </div>
                     );

--- a/src/features/session/components/LanguageSelectorGlobe.tsx
+++ b/src/features/session/components/LanguageSelectorGlobe.tsx
@@ -249,7 +249,7 @@ const LanguageSelectorGlobe: React.FC<LanguageSelectorGlobeProps> = ({
             <div className="relative w-full max-w-[20rem] aspect-square">
                 <div
                     ref={globeRef}
-                    className="globe-bg absolute inset-0 border-2 rounded-full flex items-center justify-center bg-slate-800 text-white overflow-hidden shadow-inner touch-none"
+                    className="globe-bg absolute inset-0 border-2 rounded-full flex items-center justify-center bg-primary text-white overflow-hidden shadow-inner touch-none"
                     onPointerDown={handlePointerDown}
                     onPointerMove={handlePointerMove}
                     onPointerUp={handlePointerUp}
@@ -258,7 +258,7 @@ const LanguageSelectorGlobe: React.FC<LanguageSelectorGlobeProps> = ({
                     onWheel={handleWheel}
                 >
                 {/* Spiral indicator - shows current position in the full language list */}
-                <div className="absolute top-2 left-1/2 -translate-x-1/2 text-xs text-slate-400 opacity-60 pointer-events-none">
+                <div className="absolute top-2 left-1/2 -translate-x-1/2 text-xs text-muted-foreground opacity-60 pointer-events-none">
                     {Math.floor(spiralOffset * ALL_LANGUAGES.length) + 1} / {ALL_LANGUAGES.length}
                 </div>
 
@@ -266,7 +266,7 @@ const LanguageSelectorGlobe: React.FC<LanguageSelectorGlobeProps> = ({
                     className="absolute inset-0 flex items-center justify-center pointer-events-none"
                 >
                     <div
-                        className="pointer-events-auto w-[70%] max-w-[10rem] bg-slate-900/60 backdrop-blur-md rounded-2xl px-3 py-2 transition-opacity duration-200 opacity-40 hover:opacity-100 focus-within:opacity-100 active:opacity-100 shadow-lg border border-white/10"
+                        className="pointer-events-auto w-[70%] max-w-[10rem] bg-primary/60 backdrop-blur-md rounded-2xl px-3 py-2 transition-opacity duration-200 opacity-40 hover:opacity-100 focus-within:opacity-100 active:opacity-100 shadow-lg border border-white/10"
                     >
                         <div className="flex justify-center items-start gap-3">
                             <LanguageScrollWheel

--- a/src/features/session/components/SessionControls.tsx
+++ b/src/features/session/components/SessionControls.tsx
@@ -582,7 +582,7 @@ const SessionControls: React.FC = () => {
               onKeyDown={(e) => e.key === 'Enter' && executePendingAction()}
               autoFocus
             />
-            <span className="text-xs text-slate-400 break-words">
+            <span className="text-xs text-muted-foreground break-words">
               {ACTION_CONFIG[pendingAction].description}
             </span>
           </div>
@@ -598,7 +598,7 @@ const SessionControls: React.FC = () => {
             <button
               type="button"
               onClick={cancelPendingAction}
-              className="p-2 bg-slate-700/50 hover:bg-slate-600 rounded-full text-slate-300 transition-colors"
+              className="p-2 bg-primary/50 hover:bg-primary/70 rounded-full text-primary-foreground/70 transition-colors"
             >
               <IconUndo className="w-4 h-4" />
             </button>
@@ -608,9 +608,9 @@ const SessionControls: React.FC = () => {
       ) : isEditingProfile ? (
         <div className="flex-1 flex items-start justify-between animate-fade-in gap-2">
           <div className="flex flex-col gap-1 flex-1 min-w-0">
-            <span className="text-xs font-bold text-blue-300 uppercase tracking-wider">{t('sessionControls.profile') || 'Profile:'}</span>
+            <span className="text-xs font-bold text-watercolor uppercase tracking-wider">{t('sessionControls.profile') || 'Profile:'}</span>
             <input
-              className="w-full max-w-[520px] bg-blue-950/30 border border-blue-500/30 rounded px-2 py-1.5 text-sm text-blue-100 placeholder-blue-400/30 focus:outline-none focus:border-blue-400 focus:bg-blue-950/50 transition-colors"
+              className="w-full max-w-[520px] bg-watercolor/10 border border-watercolor/30 rounded px-2 py-1.5 text-sm text-primary-foreground/80 placeholder-watercolor/30 focus:outline-none focus:border-watercolor/60 focus:bg-watercolor/15 transition-colors"
               placeholder={t('sessionControls.profilePlaceholder') || 'Your name or details...'}
               value={profileText}
               onChange={(e) => setProfileText(e.target.value)}
@@ -629,7 +629,7 @@ const SessionControls: React.FC = () => {
             <button
               type="button"
               onClick={() => setIsEditingProfile(false)}
-              className="p-2 bg-slate-700/50 hover:bg-slate-600 rounded-full text-slate-300 transition-colors"
+              className="p-2 bg-primary/50 hover:bg-primary/70 rounded-full text-primary-foreground/70 transition-colors"
             >
               <IconUndo className="w-4 h-4" />
             </button>
@@ -643,7 +643,7 @@ const SessionControls: React.FC = () => {
             <button
               type="button"
               onClick={startProfileEdit}
-              className="group p-2.5 rounded-full text-slate-400 hover:text-white hover:bg-white/10 transition-all"
+              className="group p-2.5 rounded-full text-muted-foreground hover:text-white hover:bg-white/10 transition-all"
               title={t('sessionControls.editProfile') || 'Edit User Profile'}
             >
               <IconPencil className="w-4 h-4 opacity-70 group-hover:opacity-100" />
@@ -651,53 +651,53 @@ const SessionControls: React.FC = () => {
           </div>
 
           {/* Center: Action Pill - Grouped Controls */}
-          <div className="flex items-center bg-slate-800/60 backdrop-blur-sm rounded-full p-1 border border-white/5 shadow-inner">
+          <div className="flex items-center bg-primary/60 backdrop-blur-sm rounded-full p-1 border border-white/5 shadow-inner">
             {controlMode === 'none' ? (
               /* Default: Show two group selectors */
               <>
-                <button type="button" onClick={() => setControlMode('all')} className="px-3 py-1.5 hover:bg-white/10 rounded-full text-slate-300 hover:text-white transition-colors text-xs font-medium" title={t('sessionControls.allChatsControls') || 'All Chats Controls'}>
+                <button type="button" onClick={() => setControlMode('all')} className="px-3 py-1.5 hover:bg-white/10 rounded-full text-primary-foreground/70 hover:text-white transition-colors text-xs font-medium" title={t('sessionControls.allChatsControls') || 'All Chats Controls'}>
                   {'🔧🌐💬'}
                 </button>
                 <div className="w-px h-4 bg-white/10 mx-0.5"></div>
-                <button type="button" onClick={() => setControlMode('this')} className="px-3 py-1.5 hover:bg-white/10 rounded-full text-slate-300 hover:text-white transition-colors text-xs font-medium" title={t('sessionControls.thisChatsControls') || 'This Chat Controls'}>
+                <button type="button" onClick={() => setControlMode('this')} className="px-3 py-1.5 hover:bg-white/10 rounded-full text-primary-foreground/70 hover:text-white transition-colors text-xs font-medium" title={t('sessionControls.thisChatsControls') || 'This Chat Controls'}>
                   {'🔧🎯💬'}
                 </button>
               </>
             ) : controlMode === 'all' ? (
               /* All Chats: Save All, Load All, Reset, Back */
               <>
-                <button type="button" onClick={() => setControlMode('none')} className="p-2 hover:bg-white/10 rounded-full text-slate-400 hover:text-white transition-colors" title={t('sessionControls.back') || 'Back'}>
+                <button type="button" onClick={() => setControlMode('none')} className="p-2 hover:bg-white/10 rounded-full text-muted-foreground hover:text-white transition-colors" title={t('sessionControls.back') || 'Back'}>
                   <IconUndo className="w-4 h-4" />
                 </button>
                 <div className="w-px h-4 bg-white/10 mx-0.5"></div>
-                <button type="button" onClick={() => { setPendingAction('saveAll'); setConfirmInput(''); }} className="p-2 hover:bg-white/10 rounded-full text-slate-300 hover:text-white transition-colors" title={t('startPage.saveChats') || 'Save All Chats'}>
+                <button type="button" onClick={() => { setPendingAction('saveAll'); setConfirmInput(''); }} className="p-2 hover:bg-white/10 rounded-full text-primary-foreground/70 hover:text-white transition-colors" title={t('startPage.saveChats') || 'Save All Chats'}>
                   <IconSave className="w-4 h-4" />
                 </button>
                 <div className="w-px h-4 bg-white/10 mx-0.5"></div>
-                <button type="button" onClick={() => loadFileInputRef.current?.click()} className="p-2 hover:bg-white/10 rounded-full text-slate-300 hover:text-white transition-colors" title={t('startPage.loadChats') || 'Load All Chats'}>
+                <button type="button" onClick={() => loadFileInputRef.current?.click()} className="p-2 hover:bg-white/10 rounded-full text-primary-foreground/70 hover:text-white transition-colors" title={t('startPage.loadChats') || 'Load All Chats'}>
                   <IconFolderOpen className="w-4 h-4" />
                 </button>
                 <div className="w-px h-4 bg-white/10 mx-0.5"></div>
-                <button type="button" onClick={() => { setPendingAction('reset'); setConfirmInput(''); }} className="p-2 hover:bg-red-500/20 rounded-full text-slate-300 hover:text-red-200 transition-colors" title={t('sessionControls.backupAndReset') || 'Backup & Reset'}>
+                <button type="button" onClick={() => { setPendingAction('reset'); setConfirmInput(''); }} className="p-2 hover:bg-red-500/20 rounded-full text-primary-foreground/70 hover:text-red-200 transition-colors" title={t('sessionControls.backupAndReset') || 'Backup & Reset'}>
                   <IconTrash className="w-4 h-4" />
                 </button>
               </>
             ) : (
               /* This Chat: Save This, Combine, Trim, Back */
               <>
-                <button type="button" onClick={() => setControlMode('none')} className="p-2 hover:bg-white/10 rounded-full text-slate-400 hover:text-white transition-colors" title={t('sessionControls.back') || 'Back'}>
+                <button type="button" onClick={() => setControlMode('none')} className="p-2 hover:bg-white/10 rounded-full text-muted-foreground hover:text-white transition-colors" title={t('sessionControls.back') || 'Back'}>
                   <IconUndo className="w-4 h-4" />
                 </button>
                 <div className="w-px h-4 bg-white/10 mx-0.5"></div>
-                <button type="button" onClick={() => { setPendingAction('saveThis'); setConfirmInput(''); }} className="p-2 hover:bg-white/10 rounded-full text-slate-300 hover:text-white transition-colors" title={t('startPage.saveThisChat') || 'Save This Chat'}>
+                <button type="button" onClick={() => { setPendingAction('saveThis'); setConfirmInput(''); }} className="p-2 hover:bg-white/10 rounded-full text-primary-foreground/70 hover:text-white transition-colors" title={t('startPage.saveThisChat') || 'Save This Chat'}>
                   <IconBookmark className="w-4 h-4" />
                 </button>
                 <div className="w-px h-4 bg-white/10 mx-0.5"></div>
-                <button type="button" onClick={() => appendFileInputRef.current?.click()} className="p-2 hover:bg-white/10 rounded-full text-slate-300 hover:text-white transition-colors" title={t('startPage.appendToChat') || 'Combine Chats'}>
+                <button type="button" onClick={() => appendFileInputRef.current?.click()} className="p-2 hover:bg-white/10 rounded-full text-primary-foreground/70 hover:text-white transition-colors" title={t('startPage.appendToChat') || 'Combine Chats'}>
                   <IconPlus className="w-4 h-4" />
                 </button>
                 <div className="w-px h-4 bg-white/10 mx-0.5"></div>
-                <button type="button" onClick={() => { setPendingAction('trim'); setConfirmInput(''); }} className="p-2 hover:bg-orange-500/20 rounded-full text-slate-300 hover:text-orange-200 transition-colors" title={t('startPage.trimBeforeBookmark') || 'Trim Before Bookmark'}>
+                <button type="button" onClick={() => { setPendingAction('trim'); setConfirmInput(''); }} className="p-2 hover:bg-orange-500/20 rounded-full text-primary-foreground/70 hover:text-orange-200 transition-colors" title={t('startPage.trimBeforeBookmark') || 'Trim Before Bookmark'}>
                   <IconScissors className="w-4 h-4" />
                 </button>
               </>
@@ -721,17 +721,17 @@ const SessionControls: React.FC = () => {
             <button
               type="button"
               {...{ [DATA_AVATAR_ACTION]: 'swap' }}
-              className={`absolute left-1/2 -translate-x-[24px] top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-slate-800 border border-slate-600 flex items-center justify-center text-slate-400 hover:text-white hover:bg-slate-700 hover:border-slate-500 transition-all duration-200 shadow-lg z-0 ${
+              className={`absolute left-1/2 -translate-x-[24px] top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-primary border border-border flex items-center justify-center text-muted-foreground hover:text-white hover:bg-primary/80 hover:border-border transition-all duration-200 shadow-lg z-0 ${
                 isAvatarExpanded ? '-translate-x-[36px]' : ''
               } ${
-                highlightedSide === 'left' ? 'text-white bg-slate-700 border-slate-500 z-20 scale-110 ring-2 ring-white/30' : 'hover:z-20 hover:scale-105'
+                highlightedSide === 'left' ? 'text-white bg-primary/80 border-border z-20 scale-110 ring-2 ring-white/30' : 'hover:z-20 hover:scale-105'
               }`}
               title={t('general.clear') + " / " + (t('sessionControls.changeAvatar') || 'Change Avatar')}
             >
               <IconSwap className="w-3.5 h-3.5" />
 
               <IconSwap
-                className={`absolute left-0 top-1/2 -translate-y-1/2 -translate-x-2.5 w-3 h-3 text-slate-500 transition-opacity duration-200 ${isAvatarExpanded ? 'opacity-0' : 'opacity-100'}`}
+                className={`absolute left-0 top-1/2 -translate-y-1/2 -translate-x-2.5 w-3 h-3 text-muted-foreground transition-opacity duration-200 ${isAvatarExpanded ? 'opacity-0' : 'opacity-100'}`}
               />
             </button>
  
@@ -766,15 +766,15 @@ const SessionControls: React.FC = () => {
             {/* Center: The Avatar (Visual Anchor) */}
             <div className="relative z-10 w-10 h-10 pointer-events-none">
               <div
-                className={`w-full h-full rounded-full overflow-hidden border-2 flex items-center justify-center bg-slate-900 transition-all duration-300
+                className={`w-full h-full rounded-full overflow-hidden border-2 flex items-center justify-center bg-primary transition-all duration-300
                     ${maestroAsset?.dataUrl
-                    ? 'border-blue-400/60 shadow-[0_0_15px_rgba(96,165,250,0.5)]'
-                    : 'border-slate-600 border-dashed opacity-80'}`}
+                    ? 'border-accent/60 shadow-[0_0_15px_rgba(191,106,58,0.5)]'
+                    : 'border-border border-dashed opacity-80'}`}
               >
                 {maestroAsset?.dataUrl ? (
                   <img src={maestroAsset.dataUrl} alt={t('startPage.maestroAvatar') || 'Maestro avatar'} className="w-full h-full object-cover" />
                 ) : (
-                  <IconPlus className="w-4 h-4 text-slate-500" />
+                  <IconPlus className="w-4 h-4 text-muted-foreground" />
                 )}
 
                 {isUploadingMaestro && (

--- a/src/features/speech/components/SttLanguageSelector.tsx
+++ b/src/features/speech/components/SttLanguageSelector.tsx
@@ -24,27 +24,27 @@ const SttLanguageSelector: React.FC<SttLanguageSelectorProps> = React.memo(({ ta
   const isTargetSelected = currentSttLangCode === targetCode || targetLang.code.includes(currentSttLangCode);
   const isNativeSelected = currentSttLangCode === nativeCode || nativeLang.code.includes(currentSttLangCode);
   
-  const wrapperClass = isCollapsed ? (isInSuggestionMode ? 'p-0.5 bg-gray-300/60 rounded-full' : 'p-0.5 bg-blue-400/60 rounded-full') : 'p-0.5 bg-gray-200 rounded-full';
+  const wrapperClass = isCollapsed ? (isInSuggestionMode ? 'p-0.5 bg-secondary/60 rounded-full' : 'p-0.5 bg-accent/60 rounded-full') : 'p-0.5 bg-secondary rounded-full';
   const buttonBase = isCollapsed ? 'p-1.5 rounded-full' : 'p-2 rounded-full';
   const flagBase = isCollapsed ? 'text-base leading-none' : 'text-lg leading-none';
   const selectedClassCollapsed = isInSuggestionMode ? 'bg-white/50' : 'bg-white/30';
-  const selectedClassExpanded = isInSuggestionMode ? 'bg-gray-800' : 'bg-blue-500';
+  const selectedClassExpanded = isInSuggestionMode ? 'bg-primary' : 'bg-accent';
   const unselectedHoverCollapsed = isInSuggestionMode ? 'hover:bg-black/20' : 'hover:bg-white/20';
 
   return (
     <div className={`flex items-center space-x-0.5 ${wrapperClass}`}>
-      <button 
+      <button
         onClick={() => onSelectLang(targetCode)}
-        className={`${buttonBase} transition-colors ${isTargetSelected ? (isCollapsed ? selectedClassCollapsed : selectedClassExpanded) : (isCollapsed ? `opacity-70 hover:opacity-100 ${unselectedHoverCollapsed}` : 'hover:bg-gray-300')}`}
+        className={`${buttonBase} transition-colors ${isTargetSelected ? (isCollapsed ? selectedClassCollapsed : selectedClassExpanded) : (isCollapsed ? `opacity-70 hover:opacity-100 ${unselectedHoverCollapsed}` : 'hover:bg-secondary')}`}
         title={t('sttLang.selectLanguage', { language: targetLang.displayName })}
         aria-label={t('sttLang.selectLanguage', { language: targetLang.displayName })}
         aria-pressed={isTargetSelected}
       >
         <span className={`${flagBase} ${isTargetSelected && !isCollapsed ? 'text-white' : ''}`}>{targetLang.flag}</span>
       </button>
-      <button 
+      <button
         onClick={() => onSelectLang(nativeCode)}
-        className={`${buttonBase} transition-colors ${isNativeSelected ? (isCollapsed ? selectedClassCollapsed : selectedClassExpanded) : (isCollapsed ? `opacity-70 hover:opacity-100 ${unselectedHoverCollapsed}` : 'hover:bg-gray-300')}`}
+        className={`${buttonBase} transition-colors ${isNativeSelected ? (isCollapsed ? selectedClassCollapsed : selectedClassExpanded) : (isCollapsed ? `opacity-70 hover:opacity-100 ${unselectedHoverCollapsed}` : 'hover:bg-secondary')}`}
         title={t('sttLang.selectLanguage', { language: nativeLang.displayName })}
         aria-label={t('sttLang.selectLanguage', { language: nativeLang.displayName })}
         aria-pressed={isNativeSelected}


### PR DESCRIPTION
This pull request introduces a comprehensive visual refresh to the application, implementing a new "sketch" design system. The changes focus on updating the color palette, typography, and component styling to create a hand-drawn, notebook-like aesthetic. Key updates include new CSS variables and utility classes, integration of custom Google Fonts, and adjustments to component backgrounds, borders, and animations for a more cohesive and playful user interface.

**Design System Overhaul**

* Added a new set of CSS variables in `index.css` to define the "sketch" design system, including custom colors (e.g., `--paper`, `--pencil`, `--accent`), border radii, and font families. These are now used throughout the app for consistent theming.
* Implemented decorative CSS classes for sketchy borders, underlines, notebook lines, paper textures, and tape/torn-paper effects, and applied them to relevant elements.
* Updated scrollbar, splash screen, and image placeholder spinner styles to match the new palette and style.

**Typography and Fonts**

* Integrated Google Fonts (`Caveat`, `Patrick Hand`, `Architects Daughter`) via `<link>` tags in `index.html` and configured them in Tailwind’s theme for use across the app.
* Updated the splash screen and body to use the new hand-drawn fonts, and renamed the app to "Maestro Tutor" in the splash screen. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L89-R81) [[2]](diffhunk://#diff-74509b9cbe3ed0497e4f82a238b37387f70124471353a438907f50b53d099308R5-R145)

**Component and Background Styling**

* Replaced previous gray backgrounds and borders with new theme-based classes such as `bg-background`, `bg-paper`, `bg-secondary`, and `border-border` across major layout containers and chat components for a consistent look. [[1]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L523-R544) [[2]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L572-R572) [[3]](diffhunk://#diff-ab3ce8aa9f629761724d3403d751413073de8a5e173c321203a95d8e802e2b48L505-R505) [[4]](diffhunk://#diff-ab3ce8aa9f629761724d3403d751413073de8a5e173c321203a95d8e802e2b48L525-R534) [[5]](diffhunk://#diff-ab3ce8aa9f629761724d3403d751413073de8a5e173c321203a95d8e802e2b48L550-R550) [[6]](diffhunk://#diff-ab3ce8aa9f629761724d3403d751413073de8a5e173c321203a95d8e802e2b48L571-R571)
* Added the `paper-texture` and `notebook-lines` classes to main containers for a subtle paper effect. [[1]](diffhunk://#diff-7c79023b16fd616788af0fdcb31d619ae04da7259aa564fd72fb0ea07d8ebe07L523-R544) [[2]](diffhunk://#diff-ab3ce8aa9f629761724d3403d751413073de8a5e173c321203a95d8e802e2b48L505-R505)

**Component Color and Accent Updates**

* Updated the `AudioPlayer` component to use theme colors for backgrounds, progress bars, and buttons, replacing hardcoded blues and grays with `primary`, `secondary`, and `accent` colors.
* Adjusted the bookmark actions and controls to use new theme colors for borders, backgrounds, and text, ensuring visual consistency with the rest of the design system. [[1]](diffhunk://#diff-6a5edc9a920fe0754017ba8c426704d31518320c047d1dc1501e95a71af11ae8L133-R133) [[2]](diffhunk://#diff-ab3ce8aa9f629761724d3403d751413073de8a5e173c321203a95d8e802e2b48L631-R631)

These changes collectively modernize the app’s appearance, unify its visual language, and lay the groundwork for further design-driven improvements.