### PR TITLE
feat: fix policy path, new free tier assist.

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -64,7 +64,7 @@ Select: "All or some functionality is restricted" -> Add instructions.
 
 Write: "This app requires a user-generated Google Gemini API Key. For testing purposes, please use this valid key: [PASTE_YOUR_KEY_HERE]. You can revoke this key after testing."
 
-- [X] Add privacy policy URL: `https://ronitervo.github.io/MaestroTutor/public/privacy.html`
+- [X] Add privacy policy URL: `https://ronitervo.github.io/MaestroTutor/privacy.html`
 
 ## 7) Data Safety Form
 Recommended answers:

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -513,6 +513,35 @@ const App: React.FC = () => {
     maestroAvatarMimeTypeRef,
   });
 
+  // ============================================================
+  // QUOTA ERROR ACTIONS
+  // ============================================================
+
+  const handleQuotaSetupBilling = useCallback(() => {
+    handleApiKeyGateOpen({ reason: 'quota', instructionIndex: 9 });
+  }, [handleApiKeyGateOpen]);
+
+  const handleQuotaStartLive = useCallback(async () => {
+    // Select the first available physical camera if none is selected
+    const currentCameraId = settingsRef.current.selectedCameraId;
+    if (!currentCameraId || currentCameraId === IMAGE_GEN_CAMERA_ID) {
+      const firstPhysicalCamera = availableCamerasRef.current[0];
+      if (firstPhysicalCamera) {
+        handleSettingsChange('selectedCameraId', firstPhysicalCamera.deviceId);
+      }
+    }
+    // Ensure snapshot sending is enabled so the camera feed is active
+    if (!settingsRef.current.sendWithSnapshotEnabled) {
+      handleSettingsChange('sendWithSnapshotEnabled', true);
+    }
+    // Start the live session
+    try {
+      await handleStartLiveSession();
+    } catch {
+      // handleStartLiveSession already handles its own errors
+    }
+  }, [settingsRef, availableCamerasRef, handleSettingsChange, handleStartLiveSession]);
+
 
   // ============================================================
   // RENDER
@@ -624,6 +653,8 @@ const App: React.FC = () => {
             onStopLiveSession={handleStopLiveSession}
             onToggleSuggestionMode={handleToggleSuggestionMode}
             onCreateSuggestion={handleCreateSuggestion}
+            onQuotaSetupBilling={handleQuotaSetupBilling}
+            onQuotaStartLive={handleQuotaStartLive}
           />
         </main>
       </div>

--- a/src/core/i18n/ar.ts
+++ b/src/core/i18n/ar.ts
@@ -227,7 +227,9 @@ export const arTranslations: Record<string, string> = {
   "error.tokenLimitReached": "تم الوصول إلى حد الرموز للجلسة. يرجى بدء جلسة جديدة.",
   "error.apiKeyMissing": "مفتاح Gemini API الخاص بك مفقود. افتح شاشة مفتاح API والصق مفتاحك.",
   "error.apiKeyInvalid": "مفتاح Gemini API الخاص بك غير صالح. يرجى التحقق من وجود أخطاء إملائية ولصق مفتاح صالح.",
-  "error.apiQuotaExceeded": "تم استنفاد حصة Gemini API المجانية للدردشة. لقد فتحت شاشة مفتاح API مع خطوات الفوترة. يمكنك الاستمرار في استخدام المحادثة المباشرة في هذه الأثناء.",
+  "error.apiQuotaExceeded": "تم استنفاد حصة Gemini API المجانية للدردشة.",
+  "error.quotaSetupBilling": "إعداد الفوترة",
+  "error.quotaStartLive": "ابدأ المحادثة المباشرة بدلاً من ذلك",
 
   // Errors - camera
   "error.cameraPermissionDenied": "تم رفض إذن الكاميرا. يرجى تمكين الوصول إلى الكاميرا في إعدادات المتصفح.",

--- a/src/core/i18n/bn.ts
+++ b/src/core/i18n/bn.ts
@@ -229,7 +229,9 @@ export const bnTranslations: Record<string, string> = {
   "error.tokenLimitReached": "সেশন টোকেন সীমা পূর্ণ হয়েছে। অনুগ্রহ করে নতুন সেশন শুরু করুন।",
   "error.apiKeyMissing": "আপনার Gemini API কী নেই। API Key স্ক্রিন খুলুন এবং আপনার কী পেস্ট করুন।",
   "error.apiKeyInvalid": "আপনার Gemini API কী অবৈধ। অনুগ্রহ করে বানানে ভুল আছে কিনা পরীক্ষা করুন এবং একটি বৈধ কী পেস্ট করুন।",
-  "error.apiQuotaExceeded": "চ্যাটের জন্য আপনার Gemini API-এর ফ্রি কোটা শেষ হয়ে গেছে। আমি বিলিং ধাপসহ API Key স্ক্রিন খুলেছি। এর মধ্যে আপনি এখনও লাইভ কথোপকথন ব্যবহার করতে পারেন।",
+  "error.apiQuotaExceeded": "চ্যাটের জন্য আপনার Gemini API-এর ফ্রি কোটা শেষ হয়ে গেছে।",
+  "error.quotaSetupBilling": "বিলিং সেট আপ করুন",
+  "error.quotaStartLive": "পরিবর্তে লাইভ শুরু করুন",
 
   // Errors - camera
   "error.cameraPermissionDenied": "ক্যামেরা অনুমতি প্রত্যাখ্যাত। ব্রাউজার সেটিংসে ক্যামেরা অ্যাক্সেস সক্রিয় করুন।",

--- a/src/core/i18n/de.ts
+++ b/src/core/i18n/de.ts
@@ -227,7 +227,9 @@ export const deTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Sitzungs-Token-Limit erreicht. Bitte neue Sitzung starten.",
   "error.apiKeyMissing": "Ihr Gemini-API-Schlüssel fehlt. Öffnen Sie den API-Schlüssel-Bildschirm und fügen Sie Ihren Schlüssel ein.",
   "error.apiKeyInvalid": "Ihr Gemini-API-Schlüssel ist ungültig. Bitte prüfen Sie auf Tippfehler und fügen Sie einen gültigen Schlüssel ein.",
-  "error.apiQuotaExceeded": "Ihr kostenloses Gemini-API-Kontingent für den Chat ist erschöpft. Ich habe den API-Schlüssel-Bildschirm mit den Abrechnungsschritten geöffnet. In der Zwischenzeit können Sie weiterhin die Live-Unterhaltung nutzen.",
+  "error.apiQuotaExceeded": "Ihr kostenloses Gemini-API-Kontingent für den Chat ist erschöpft.",
+  "error.quotaSetupBilling": "Abrechnung einrichten",
+  "error.quotaStartLive": "Stattdessen Live starten",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Kameraberechtigung verweigert. Bitte aktivieren Sie den Kamerazugriff in Ihren Browsereinstellungen.",

--- a/src/core/i18n/en.ts
+++ b/src/core/i18n/en.ts
@@ -234,7 +234,9 @@ export const enTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Session token limit reached. Please start a new session.",
   "error.apiKeyMissing": "Your Gemini API key is missing. Open the API Key screen and paste your key.",
   "error.apiKeyInvalid": "Your Gemini API key is invalid. Please check for typos and paste a valid key.",
-  "error.apiQuotaExceeded": "Your Gemini API free quota for chat is exhausted. I opened the API Key screen with billing steps. You can still use Live conversation in the meantime.",
+  "error.apiQuotaExceeded": "Your Gemini API free quota for chat is exhausted.",
+  "error.quotaSetupBilling": "Set up billing",
+  "error.quotaStartLive": "Start Live instead",
   
   // Errors - camera
   "error.cameraPermissionDenied": "Camera permission denied. Please enable camera access in your browser settings.",

--- a/src/core/i18n/es.ts
+++ b/src/core/i18n/es.ts
@@ -229,7 +229,9 @@ export const esTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Límite de tokens de la sesión alcanzado. Por favor inicia una nueva sesión.",
   "error.apiKeyMissing": "Falta tu clave API de Gemini. Abre la pantalla de clave API y pega tu clave.",
   "error.apiKeyInvalid": "Tu clave API de Gemini no es válida. Por favor, comprueba si hay errores tipográficos y pega una clave válida.",
-  "error.apiQuotaExceeded": "Tu cuota gratuita de la API de Gemini para el chat se ha agotado. He abierto la pantalla de clave API con los pasos de facturación. Mientras tanto, aún puedes usar la conversación en vivo.",
+  "error.apiQuotaExceeded": "Tu cuota gratuita de la API de Gemini para el chat se ha agotado.",
+  "error.quotaSetupBilling": "Configurar facturación",
+  "error.quotaStartLive": "Iniciar Live en su lugar",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Permiso de cámara denegado. Por favor habilita el acceso a la cámara en la configuración de tu navegador.",

--- a/src/core/i18n/fi.ts
+++ b/src/core/i18n/fi.ts
@@ -229,7 +229,9 @@ export const fiTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Istunnon token-raja saavutettu. Aloita uusi istunto.",
   "error.apiKeyMissing": "Gemini API -avaimesi puuttuu. Avaa API-avainnäkymä ja liitä avaimesi.",
   "error.apiKeyInvalid": "Gemini API -avaimesi on virheellinen. Tarkista kirjoitusvirheet ja liitä kelvollinen avain.",
-  "error.apiQuotaExceeded": "Gemini API:n ilmainen chat-kiintiösi on lopussa. Avasin API-avainnäkymän, jossa on laskutusohjeet. Voit silti käyttää Live-keskustelua sillä välin.",
+  "error.apiQuotaExceeded": "Gemini API:n ilmainen chat-kiintiösi on lopussa.",
+  "error.quotaSetupBilling": "Määritä laskutus",
+  "error.quotaStartLive": "Käynnistä Live sen sijaan",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Kameran käyttöoikeus evätty. Ota kameran käyttöoikeus käyttöön selaimen asetuksissa.",

--- a/src/core/i18n/fr.ts
+++ b/src/core/i18n/fr.ts
@@ -229,7 +229,9 @@ export const frTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Limite de tokens de la session atteinte. Veuillez démarrer une nouvelle session.",
   "error.apiKeyMissing": "Votre clé API Gemini est manquante. Ouvrez l'écran de la clé API et collez votre clé.",
   "error.apiKeyInvalid": "Votre clé API Gemini est invalide. Veuillez vérifier les fautes de frappe et coller une clé valide.",
-  "error.apiQuotaExceeded": "Votre quota gratuit Gemini API pour le chat est épuisé. J'ai ouvert l'écran de la clé API avec les étapes de facturation. Vous pouvez toujours utiliser la conversation en direct en attendant.",
+  "error.apiQuotaExceeded": "Votre quota gratuit Gemini API pour le chat est épuisé.",
+  "error.quotaSetupBilling": "Configurer la facturation",
+  "error.quotaStartLive": "Démarrer Live à la place",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Permission caméra refusée. Veuillez activer l'accès caméra dans les paramètres de votre navigateur.",

--- a/src/core/i18n/gu.ts
+++ b/src/core/i18n/gu.ts
@@ -229,7 +229,9 @@ export const guTranslations: Record<string, string> = {
   "error.tokenLimitReached": "સત્ર ટોકન મર્યાદા પૂરી થઈ. કૃપા કરીને નવું સત્ર શરૂ કરો.",
   "error.apiKeyMissing": "તમારી Gemini API કી ખૂટે છે. API કી સ્ક્રીન ખોલો અને તમારી કી પેસ્ટ કરો.",
   "error.apiKeyInvalid": "તમારી Gemini API કી અમાન્ય છે. કૃપા કરીને ટાઈપો માટે તપાસો અને માન્ય કી પેસ્ટ કરો.",
-  "error.apiQuotaExceeded": "ચેટ માટે તમારો Gemini API ફ્રી ક્વોટા સમાપ્ત થઈ ગયો છે. મેં બિલિંગ સ્ટેપ્સ સાથે API કી સ્ક્રીન ખોલી છે. તમે તે દરમિયાન હજુ પણ લાઈવ વાતચીતનો ઉપયોગ કરી શકો છો.",
+  "error.apiQuotaExceeded": "ચેટ માટે તમારો Gemini API ફ્રી ક્વોટા સમાપ્ત થઈ ગયો છે.",
+  "error.quotaSetupBilling": "બિલિંગ સેટ કરો",
+  "error.quotaStartLive": "તેના બદલે લાઈવ શરૂ કરો",
 
   // Errors - camera
   "error.cameraPermissionDenied": "કેમેરા પરવાનગી નકારી. બ્રાઉઝર સેટિંગ્સમાં કેમેરા ઍક્સેસ સક્ષમ કરો.",

--- a/src/core/i18n/hi.ts
+++ b/src/core/i18n/hi.ts
@@ -229,7 +229,9 @@ export const hiTranslations: Record<string, string> = {
   "error.tokenLimitReached": "सत्र टोकन सीमा पूरी हो गई। कृपया नया सत्र शुरू करें।",
   "error.apiKeyMissing": "आपकी Gemini API कुंजी गायब है। API कुंजी स्क्रीन खोलें और अपनी कुंजी पेस्ट करें।",
   "error.apiKeyInvalid": "आपकी Gemini API कुंजी अमान्य है। कृपया टाइपो की जांच करें और एक वैध कुंजी पेस्ट करें।",
-  "error.apiQuotaExceeded": "चैट के लिए आपका Gemini API फ्री कोटा समाप्त हो गया है। मैंने बिलिंग चरणों के साथ API कुंजी स्क्रीन खोल दी है। आप इस बीच अभी भी लाइव बातचीत का उपयोग कर सकते हैं।",
+  "error.apiQuotaExceeded": "चैट के लिए आपका Gemini API फ्री कोटा समाप्त हो गया है।",
+  "error.quotaSetupBilling": "बिलिंग सेट अप करें",
+  "error.quotaStartLive": "इसके बजाय लाइव शुरू करें",
 
   // Errors - camera
   "error.cameraPermissionDenied": "कैमरा अनुमति अस्वीकृत। कृपया ब्राउज़र सेटिंग्स में कैमरा एक्सेस सक्षम करें।",

--- a/src/core/i18n/id.ts
+++ b/src/core/i18n/id.ts
@@ -229,7 +229,9 @@ export const idTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Batas token sesi tercapai. Silakan mulai sesi baru.",
   "error.apiKeyMissing": "Kunci Gemini API Anda hilang. Buka layar Kunci API dan tempelkan kunci Anda.",
   "error.apiKeyInvalid": "Kunci Gemini API Anda tidak valid. Silakan periksa kesalahan ketik dan tempelkan kunci yang valid.",
-  "error.apiQuotaExceeded": "Kuota gratis Gemini API Anda untuk obrolan telah habis. Saya membuka layar Kunci API dengan langkah-langkah penagihan. Anda masih dapat menggunakan percakapan Langsung sementara itu.",
+  "error.apiQuotaExceeded": "Kuota gratis Gemini API Anda untuk obrolan telah habis.",
+  "error.quotaSetupBilling": "Atur penagihan",
+  "error.quotaStartLive": "Mulai Live sebagai gantinya",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Izin kamera ditolak. Silakan aktifkan akses kamera di pengaturan browser.",

--- a/src/core/i18n/it.ts
+++ b/src/core/i18n/it.ts
@@ -229,7 +229,9 @@ export const itTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Limite token della sessione raggiunto. Avvia una nuova sessione.",
   "error.apiKeyMissing": "La tua chiave API Gemini è mancante. Apri la schermata della chiave API e incolla la tua chiave.",
   "error.apiKeyInvalid": "La tua chiave API Gemini non è valida. Controlla eventuali errori di battitura e incolla una chiave valida.",
-  "error.apiQuotaExceeded": "La tua quota gratuita dell'API Gemini per la chat è esaurita. Ho aperto la schermata della chiave API con i passaggi per la fatturazione. Nel frattempo puoi ancora usare la conversazione dal vivo.",
+  "error.apiQuotaExceeded": "La tua quota gratuita dell'API Gemini per la chat è esaurita.",
+  "error.quotaSetupBilling": "Configura fatturazione",
+  "error.quotaStartLive": "Avvia Live invece",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Permesso fotocamera negato. Abilita l'accesso alla fotocamera nelle impostazioni del browser.",

--- a/src/core/i18n/ja.ts
+++ b/src/core/i18n/ja.ts
@@ -229,7 +229,9 @@ export const jaTranslations: Record<string, string> = {
   "error.tokenLimitReached": "セッションのトークン制限に達しました。新しいセッションを開始してください。",
   "error.apiKeyMissing": "Gemini APIキーが見つかりません。APIキー画面を開いてキーを貼り付けてください。",
   "error.apiKeyInvalid": "Gemini APIキーが無効です。誤字脱字を確認し、有効なキーを貼り付けてください。",
-  "error.apiQuotaExceeded": "チャット用のGemini API無料枠を使い果たしました。課金手順を含むAPIキー画面を開きました。その間もライブ会話は引き続きご利用いただけます。",
+  "error.apiQuotaExceeded": "チャット用のGemini API無料枠を使い果たしました。",
+  "error.quotaSetupBilling": "課金を設定",
+  "error.quotaStartLive": "代わりにライブを開始",
 
   // Errors - camera
   "error.cameraPermissionDenied": "カメラの許可が拒否されました。ブラウザの設定でカメラへのアクセスを有効にしてください。",

--- a/src/core/i18n/kn.ts
+++ b/src/core/i18n/kn.ts
@@ -229,7 +229,9 @@ export const knTranslations: Record<string, string> = {
   "error.tokenLimitReached": "ಸೆಷನ್ ಟೋಕನ್ ಮಿತಿ ತಲುಪಿದೆ. ದಯವಿಟ್ಟು ಹೊಸ ಸೆಷನ್ ಪ್ರಾರಂಭಿಸಿ.",
   "error.apiKeyMissing": "ನಿಮ್ಮ Gemini API ಕೀ ಕಾಣೆಯಾಗಿದೆ. API ಕೀ ಪರದೆಯನ್ನು ತೆರೆಯಿರಿ ಮತ್ತು ನಿಮ್ಮ ಕೀಯನ್ನು ಅಂಟಿಸಿ.",
   "error.apiKeyInvalid": "ನಿಮ್ಮ Gemini API ಕೀ ಅಮಾನ್ಯವಾಗಿದೆ. ದಯವಿಟ್ಟು ಕಾಗುಣಿತ ತಪ್ಪುಗಳನ್ನು ಪರಿಶೀಲಿಸಿ ಮತ್ತು ಮಾನ್ಯವಾದ ಕೀಯನ್ನು ಅಂಟಿಸಿ.",
-  "error.apiQuotaExceeded": "ಚಾಟ್‌ಗಾಗಿ ನಿಮ್ಮ Gemini API ಉಚಿತ ಮಿತಿ ಮುಗಿದಿದೆ. ಬಿಲ್ಲಿಂಗ್ ಹಂತಗಳೊಂದಿಗೆ ನಾನು API ಕೀ ಪರದೆಯನ್ನು ತೆರೆದಿದ್ದೇನೆ. ಈ ಮಧ್ಯೆ ನೀವು ಇನ್ನೂ ಲೈವ್ ಸಂಭಾಷಣೆಯನ್ನು ಬಳಸಬಹುದು.",
+  "error.apiQuotaExceeded": "ಚಾಟ್‌ಗಾಗಿ ನಿಮ್ಮ Gemini API ಉಚಿತ ಮಿತಿ ಮುಗಿದಿದೆ.",
+  "error.quotaSetupBilling": "ಬಿಲ್ಲಿಂಗ್ ಸೆಟ್ ಅಪ್ ಮಾಡಿ",
+  "error.quotaStartLive": "ಬದಲಿಗೆ ಲೈವ್ ಪ್ರಾರಂಭಿಸಿ",
 
   // Errors - camera
   "error.cameraPermissionDenied": "ಕ್ಯಾಮರಾ ಅನುಮತಿ ನಿರಾಕರಿಸಲಾಗಿದೆ. ಬ್ರೌಸರ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಕ್ಯಾಮರಾ ಪ್ರವೇಶವನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ.",

--- a/src/core/i18n/ko.ts
+++ b/src/core/i18n/ko.ts
@@ -229,7 +229,9 @@ export const koTranslations: Record<string, string> = {
   "error.tokenLimitReached": "세션 토큰 한도에 도달했습니다. 새 세션을 시작해 주세요.",
   "error.apiKeyMissing": "Gemini API 키가 누락되었습니다. API 키 화면을 열고 키를 붙여넣으세요.",
   "error.apiKeyInvalid": "Gemini API 키가 유효하지 않습니다. 오타가 있는지 확인하고 유효한 키를 붙여넣으세요.",
-  "error.apiQuotaExceeded": "Gemini API의 무료 채팅 할당량이 소진되었습니다. 결제 단계가 포함된 API 키 화면을 열었습니다. 그동안 라이브 대화를 계속 사용할 수 있습니다.",
+  "error.apiQuotaExceeded": "Gemini API의 무료 채팅 할당량이 소진되었습니다.",
+  "error.quotaSetupBilling": "결제 설정",
+  "error.quotaStartLive": "대신 라이브 시작",
 
   // Errors - camera
   "error.cameraPermissionDenied": "카메라 권한이 거부되었습니다. 브라우저 설정에서 카메라 액세스를 활성화하세요.",

--- a/src/core/i18n/ml.ts
+++ b/src/core/i18n/ml.ts
@@ -229,7 +229,9 @@ export const mlTranslations: Record<string, string> = {
   "error.tokenLimitReached": "സെഷൻ ടോക്കൺ പരിധി എത്തി. ദയവായി പുതിയ സെഷൻ ആരംഭിക്കുക.",
   "error.apiKeyMissing": "നിങ്ങളുടെ Gemini API കീ കാണാനില്ല. API കീ സ്ക്രീൻ തുറന്ന് കീ ഒട്ടിക്കുക.",
   "error.apiKeyInvalid": "നിങ്ങളുടെ Gemini API കീ അസാധുവാണ്. അക്ഷരത്തെറ്റുകൾ ഉണ്ടോ എന്ന് പരിശോധിക്കുക.",
-  "error.apiQuotaExceeded": "ചാറ്ററ്റിനായുള്ള നിങ്ങളുടെ Gemini API സൗജന്യ ക്വോട്ട തീർന്നു. ബില്ലിംഗ് ഘട്ടങ്ങളുള്ള API കീ സ്ക്രീൻ ഞാൻ തുറന്നു. അതിനിടയിൽ നിങ്ങൾക്ക് ലൈവ് സംഭാഷണം ഉപയോഗിക്കാം.",
+  "error.apiQuotaExceeded": "ചാറ്റിനായുള്ള നിങ്ങളുടെ Gemini API സൗജന്യ ക്വോട്ട തീർന്നു.",
+  "error.quotaSetupBilling": "ബില്ലിംഗ് സജ്ജീകരിക്കുക",
+  "error.quotaStartLive": "പകരം ലൈവ് ആരംഭിക്കുക",
 
   // Errors - camera
   "error.cameraPermissionDenied": "ക്യാമറ അനുമതി നിരസിച്ചു. ബ്രൗസർ ക്രമീകരണങ്ങളിൽ ക്യാമറ ആക്സസ് പ്രവർത്തനക്ഷമമാക്കുക.",

--- a/src/core/i18n/mr.ts
+++ b/src/core/i18n/mr.ts
@@ -229,7 +229,9 @@ export const mrTranslations: Record<string, string> = {
   "error.tokenLimitReached": "सत्र टोकन मर्यादा गाठली. कृपया नवीन सत्र सुरू करा.",
   "error.apiKeyMissing": "तुमची Gemini API की गहाळ आहे. API की स्क्रीन उघडा आणि तुमची की पेस्ट करा.",
   "error.apiKeyInvalid": "तुमची Gemini API की अवैध आहे. कृपया टायपो तपासा आणि वैध की पेस्ट करा.",
-  "error.apiQuotaExceeded": "तुमचा चॅटसाठीचा Gemini API मोफत कोटा संपला आहे. मी बिलिंग चरणांसह API की स्क्रीन उघडली आहे. तुम्ही तोपर्यंत लाइव्ह संभाषण वापरू शकता.",
+  "error.apiQuotaExceeded": "तुमचा चॅटसाठीचा Gemini API मोफत कोटा संपला आहे.",
+  "error.quotaSetupBilling": "बिलिंग सेट करा",
+  "error.quotaStartLive": "त्याऐवजी लाइव्ह सुरू करा",
 
   // Errors - camera
   "error.cameraPermissionDenied": "कॅमेरा परवानगी नाकारली. ब्राउझर सेटिंग्जमध्ये कॅमेरा प्रवेश सक्षम करा.",

--- a/src/core/i18n/nl.ts
+++ b/src/core/i18n/nl.ts
@@ -229,7 +229,9 @@ export const nlTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Sessietokenlimiet bereikt. Start een nieuwe sessie.",
   "error.apiKeyMissing": "Je Gemini API-sleutel ontbreekt. Open het API-sleutelscherm en plak je sleutel.",
   "error.apiKeyInvalid": "Je Gemini API-sleutel is ongeldig. Controleer op typefouten en plak een geldige sleutel.",
-  "error.apiQuotaExceeded": "Je gratis Gemini API-quotum voor chat is opgebruikt. Ik heb het API-sleutelscherm geopend met factureringsstappen. Ondertussen kun je nog steeds Live-conversatie gebruiken.",
+  "error.apiQuotaExceeded": "Je gratis Gemini API-quotum voor chat is opgebruikt.",
+  "error.quotaSetupBilling": "Facturering instellen",
+  "error.quotaStartLive": "Start Live in plaats daarvan",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Cameratoestemming geweigerd. Schakel cameratoegang in via browserinstellingen.",

--- a/src/core/i18n/pl.ts
+++ b/src/core/i18n/pl.ts
@@ -229,7 +229,9 @@ export const plTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Osiągnięto limit tokenów sesji. Rozpocznij nową sesję.",
   "error.apiKeyMissing": "Brak klucza API Gemini. Otwórz ekran klucza API i wklej swój klucz.",
   "error.apiKeyInvalid": "Klucz API Gemini jest nieprawidłowy. Sprawdź, czy nie ma literówek i wklej prawidłowy klucz.",
-  "error.apiQuotaExceeded": "Twój bezpłatny limit Gemini API na czat został wyczerpany. Otworzyłem ekran klucza API z krokami rozliczeniowymi. W międzyczasie nadal możesz korzystać z rozmowy na żywo.",
+  "error.apiQuotaExceeded": "Twój bezpłatny limit Gemini API na czat został wyczerpany.",
+  "error.quotaSetupBilling": "Skonfiguruj rozliczenia",
+  "error.quotaStartLive": "Zacznij rozmowę na żywo",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Odmówiono dostępu do kamery. Włącz dostęp do kamery w ustawieniach przeglądarki.",

--- a/src/core/i18n/pt.ts
+++ b/src/core/i18n/pt.ts
@@ -229,7 +229,9 @@ export const ptTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Limite de tokens da sessão atingido. Por favor, inicie uma nova sessão.",
   "error.apiKeyMissing": "Sua chave API do Gemini está faltando. Abra a tela de chave API e cole sua chave.",
   "error.apiKeyInvalid": "Sua chave API do Gemini é inválida. Verifique se há erros de digitação e cole uma chave válida.",
-  "error.apiQuotaExceeded": "Sua cota gratuita da API Gemini para chat esgotou. Abri a tela de chave API com passos de faturamento. Você ainda pode usar a conversa ao vivo enquanto isso.",
+  "error.apiQuotaExceeded": "Sua cota gratuita da API Gemini para chat esgotou.",
+  "error.quotaSetupBilling": "Configurar faturamento",
+  "error.quotaStartLive": "Iniciar Live em vez disso",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Permissão da câmera negada. Por favor, habilite o acesso à câmera nas configurações do seu navegador.",

--- a/src/core/i18n/ru.ts
+++ b/src/core/i18n/ru.ts
@@ -229,7 +229,9 @@ export const ruTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Достигнут лимит токенов сессии. Пожалуйста, начните новую сессию.",
   "error.apiKeyMissing": "Ваш ключ API Gemini отсутствует. Откройте экран ключа API и вставьте свой ключ.",
   "error.apiKeyInvalid": "Ваш ключ API Gemini недействителен. Пожалуйста, проверьте на наличие опечаток и вставьте действующий ключ.",
-  "error.apiQuotaExceeded": "Ваша бесплатная квота Gemini API для чата исчерпана. Я открыл экран ключа API с инструкциями по биллингу. Вы все еще можете использовать живое общение в это время.",
+  "error.apiQuotaExceeded": "Ваша бесплатная квота Gemini API для чата исчерпана.",
+  "error.quotaSetupBilling": "Настроить биллинг",
+  "error.quotaStartLive": "Начать Live вместо этого",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Разрешение на использование камеры отклонено. Пожалуйста, включите доступ к камере в настройках вашего браузера.",

--- a/src/core/i18n/sv.ts
+++ b/src/core/i18n/sv.ts
@@ -229,7 +229,9 @@ export const svTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Sessionens tokengräns nådd. Starta en ny session.",
   "error.apiKeyMissing": "Din Gemini API-nyckel saknas. Öppna API-nyckelskärmen och klistra in din nyckel.",
   "error.apiKeyInvalid": "Din Gemini API-nyckel är ogiltig. Kontrollera om det finns stavfel och klistra in en giltig nyckel.",
-  "error.apiQuotaExceeded": "Din Gemini API-gratiskvot för chatt är förbrukad. Jag öppnade API-nyckelskärmen med faktureringssteg. Du kan fortfarande använda Live-konversation under tiden.",
+  "error.apiQuotaExceeded": "Din Gemini API-gratiskvot för chatt är förbrukad.",
+  "error.quotaSetupBilling": "Konfigurera fakturering",
+  "error.quotaStartLive": "Starta Live istället",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Kamerabehörighet nekad. Aktivera kameraåtkomst i webbläsarens inställningar.",

--- a/src/core/i18n/ta.ts
+++ b/src/core/i18n/ta.ts
@@ -229,7 +229,9 @@ export const taTranslations: Record<string, string> = {
   "error.tokenLimitReached": "அமர்வு டோக்கன் வரம்பை அடைந்தது. புதிய அமர்வைத் தொடங்கவும்.",
   "error.apiKeyMissing": "உங்கள் Gemini API சாவி இல்லை. API சாவி திரையைத் திறந்து உங்கள் சாவியை ஒட்டவும்.",
   "error.apiKeyInvalid": "உங்கள் Gemini API சாவி தவறானது. எழுத்துப் பிழைகளைச் சரிபார்த்து சரியான சாவியை ஒட்டவும்.",
-  "error.apiQuotaExceeded": "அரட்டைக்கான உங்கள் Gemini API இலவச ஒதுக்கீடு முடிந்தது. பில்லிங் படிகளுடன் API சாவி திரையைத் திறந்தேன். இதற்கிடையில் நீங்கள் நேரடி உரையாடலைப் பயன்படுத்தலாம்.",
+  "error.apiQuotaExceeded": "அரட்டைக்கான உங்கள் Gemini API இலவச ஒதுக்கீடு முடிந்தது.",
+  "error.quotaSetupBilling": "பில்லிங் அமைக்கவும்",
+  "error.quotaStartLive": "அதற்கு பதிலாக நேரடியைத் தொடங்கவும்",
 
   // Errors - camera
   "error.cameraPermissionDenied": "கேமரா அனுமதி மறுக்கப்பட்டது. உலாவி அமைப்புகளில் கேமரா அணுகலை இயக்கவும்.",

--- a/src/core/i18n/te.ts
+++ b/src/core/i18n/te.ts
@@ -229,7 +229,9 @@ export const teTranslations: Record<string, string> = {
   "error.tokenLimitReached": "సెషన్ టోకెన్ పరిమితి చేరుకుంది. దయచేసి కొత్త సెషన్ ప్రారంభించండి.",
   "error.apiKeyMissing": "మీ Gemini API కీ లేదు. API కీ స్క్రీన్‌ను తెరిచి మీ కీని అతికించండి.",
   "error.apiKeyInvalid": "మీ Gemini API కీ చెల్లదు. దయచేసి టైపోల కోసం తనిఖీ చేసి, చెల్లుబాటు అయ్యే కీని అతికించండి.",
-  "error.apiQuotaExceeded": "చాట్ కోసం మీ Gemini API ఉచిత కోటా ముగిసింది. నేను బిల్లింగ్ దశలతో API కీ స్క్రీన్‌ను తెరిచాను. ఈలోపు మీరు లైవ్ సంభాషణను ఉపయోగించవచ్చు.",
+  "error.apiQuotaExceeded": "చాట్ కోసం మీ Gemini API ఉచిత కోటా ముగిసింది.",
+  "error.quotaSetupBilling": "బిల్లింగ్ సెటప్ చేయండి",
+  "error.quotaStartLive": "బదులుగా లైవ్ ప్రారంభించండి",
 
   // Errors - camera
   "error.cameraPermissionDenied": "కెమెరా అనుమతి నిరాకరించబడింది. బ్రౌజర్ సెట్టింగ్‌లలో కెమెరా యాక్సెస్‌ని ఎనేబుల్ చేయండి.",

--- a/src/core/i18n/th.ts
+++ b/src/core/i18n/th.ts
@@ -229,7 +229,9 @@ export const thTranslations: Record<string, string> = {
   "error.tokenLimitReached": "ถึงขีดจำกัดโทเค็นของเซสชันแล้ว กรุณาเริ่มเซสชันใหม่",
   "error.apiKeyMissing": "คีย์ API Gemini ของคุณหายไป เปิดหน้าจอคีย์ API และวางคีย์ของคุณ",
   "error.apiKeyInvalid": "คีย์ API Gemini ของคุณไม่ถูกต้อง โปรดตรวจสอบการสะกดผิดและวางคีย์ที่ถูกต้อง",
-  "error.apiQuotaExceeded": "โควตาฟรีของ Gemini API สำหรับแชทของคุณหมดแล้ว ฉันได้เปิดหน้าจอคีย์ API พร้อมขั้นตอนการเรียกเก็บเงิน ในระหว่างนี้คุณยังสามารถใช้การสนทนาสดได้",
+  "error.apiQuotaExceeded": "โควตาฟรีของ Gemini API สำหรับแชทของคุณหมดแล้ว",
+  "error.quotaSetupBilling": "ตั้งค่าการเรียกเก็บเงิน",
+  "error.quotaStartLive": "เริ่ม Live แทน",
 
   // Errors - camera
   "error.cameraPermissionDenied": "ปฏิเสธการอนุญาตกล้อง กรุณาเปิดใช้งานการเข้าถึงกล้องในการตั้งค่าเบราว์เซอร์",

--- a/src/core/i18n/tr.ts
+++ b/src/core/i18n/tr.ts
@@ -229,7 +229,9 @@ export const trTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Oturum belirteç (token) sınırına ulaşıldı. Lütfen yeni bir oturum başlatın.",
   "error.apiKeyMissing": "Gemini API anahtarınız eksik. API Anahtarı ekranını açın ve anahtarınızı yapıştırın.",
   "error.apiKeyInvalid": "Gemini API anahtarınız geçersiz. Lütfen yazım hatalarını kontrol edin ve geçerli bir anahtar yapıştırın.",
-  "error.apiQuotaExceeded": "Sohbet için ücretsiz Gemini API kotanız doldu. Faturalandırma adımlarını içeren API Anahtarı ekranını açtım. Bu sırada hala Canlı sohbeti kullanmaya devam edebilirsiniz.",
+  "error.apiQuotaExceeded": "Sohbet için ücretsiz Gemini API kotanız doldu.",
+  "error.quotaSetupBilling": "Faturalandırmayı ayarlayın",
+  "error.quotaStartLive": "Bunun yerine Canlı başlatın",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Kamera izni reddedildi. Lütfen tarayıcı ayarlarından kamera erişimine izin verin.",

--- a/src/core/i18n/vi.ts
+++ b/src/core/i18n/vi.ts
@@ -229,7 +229,9 @@ export const viTranslations: Record<string, string> = {
   "error.tokenLimitReached": "Đã đạt giới hạn token của phiên. Vui lòng bắt đầu phiên mới.",
   "error.apiKeyMissing": "Thiếu khóa Gemini API của bạn. Mở màn hình Khóa API và dán khóa của bạn vào.",
   "error.apiKeyInvalid": "Khóa Gemini API của bạn không hợp lệ. Vui lòng kiểm tra lỗi chính tả và dán khóa hợp lệ.",
-  "error.apiQuotaExceeded": "Hạn ngạch miễn phí Gemini API cho trò chuyện của bạn đã hết. Tôi đã mở màn hình Khóa API với các bước thanh toán. Trong thời gian chờ đợi, bạn vẫn có thể sử dụng Trò chuyện trực tiếp.",
+  "error.apiQuotaExceeded": "Hạn ngạch miễn phí Gemini API cho trò chuyện của bạn đã hết.",
+  "error.quotaSetupBilling": "Thiết lập thanh toán",
+  "error.quotaStartLive": "Bắt đầu Trực tiếp thay thế",
 
   // Errors - camera
   "error.cameraPermissionDenied": "Quyền camera bị từ chối. Vui lòng bật quyền truy cập camera trong cài đặt trình duyệt.",

--- a/src/core/i18n/zh.ts
+++ b/src/core/i18n/zh.ts
@@ -229,7 +229,9 @@ export const zhTranslations: Record<string, string> = {
   "error.tokenLimitReached": "已达到会话令牌限制。请开始新会话。",
   "error.apiKeyMissing": "您的 Gemini API 密钥缺失。打开 API 密钥屏幕并粘贴您的密钥。",
   "error.apiKeyInvalid": "您的 Gemini API 密钥无效。请检查拼写错误并粘贴有效的密钥。",
-  "error.apiQuotaExceeded": "您的 Gemini API 免费聊天配额已用尽。我已打开带有计费步骤的 API 密钥屏幕。在此期间，您仍可以使用实时对话。",
+  "error.apiQuotaExceeded": "您的 Gemini API 免费聊天配额已用尽。",
+  "error.quotaSetupBilling": "设置计费",
+  "error.quotaStartLive": "改用实时对话",
 
   // Errors - camera
   "error.cameraPermissionDenied": "相机权限被拒绝。请在浏览器设置中启用相机访问。",

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -35,6 +35,8 @@ export interface ChatMessage {
   imageGenerationStartTime?: number;
   tempSelectedNativeLangCode?: string;
   tempSelectedTargetLangCode?: string;
+  /** Optional action hint for error messages (e.g. 'quota') to render contextual action buttons */
+  errorAction?: string;
 }
 
 export interface SpeechPart {

--- a/src/features/chat/components/BookmarkActions.tsx
+++ b/src/features/chat/components/BookmarkActions.tsx
@@ -61,7 +61,7 @@ const BookmarkActions: React.FC<BookmarkActionsProps> = ({ t, message, maxVisibl
     if (n !== maxVisibleMessages) onChangeMaxVisibleMessages(n);
   };
 
-  const containerClasses = "flex items-center gap-1 px-1.5 py-0.5 bg-amber-500/90 text-white border border-amber-400 rounded-full shadow-md";
+  const containerClasses = "flex items-center gap-1 px-1.5 py-0.5 bg-accent/90 text-accent-foreground sketchy-border-thin shadow-sm";
 
   if (isEditing) {
     return (
@@ -71,14 +71,14 @@ const BookmarkActions: React.FC<BookmarkActionsProps> = ({ t, message, maxVisibl
           value={summaryText}
           onChange={(e) => setSummaryText(e.target.value)}
           onKeyDown={handleKeyDown}
-          className="bg-black/10 border border-white/30 rounded px-2 py-0.5 text-xs text-white placeholder-white/60 focus:outline-none focus:border-white focus:bg-black/20 w-48 transition-colors"
+          className="bg-card/80 border border-pencil-light/30 rounded-sketchy px-2 py-0.5 text-xs text-foreground placeholder-muted-foreground/60 focus:outline-none focus:border-accent focus:bg-card w-48 transition-colors font-hand"
           placeholder="Summary..."
           autoFocus
         />
         <button
           type="button"
           onClick={save}
-          className="p-1 rounded-full hover:bg-amber-400/50 text-white transition-colors"
+          className="p-1 rounded-sketchy hover:bg-accent/50 text-accent-foreground transition-colors"
           title="Save"
         >
           <IconCheck className="w-3.5 h-3.5" />
@@ -86,7 +86,7 @@ const BookmarkActions: React.FC<BookmarkActionsProps> = ({ t, message, maxVisibl
         <button
           type="button"
           onClick={cancel}
-          className="p-1 rounded-full hover:bg-amber-400/50 text-white transition-colors"
+          className="p-1 rounded-sketchy hover:bg-accent/50 text-accent-foreground transition-colors"
           title="Cancel"
         >
           <IconXMark className="w-3.5 h-3.5" />
@@ -107,14 +107,14 @@ const BookmarkActions: React.FC<BookmarkActionsProps> = ({ t, message, maxVisibl
         type="button"
         onClick={dec}
         disabled={maxVisibleMessages <= 2}
-        className="px-2 py-0.5 text-xs rounded-full hover:bg-amber-400/30 disabled:opacity-50"
+        className="px-2 py-0.5 text-xs font-hand rounded-sketchy hover:bg-accent/30 disabled:opacity-50"
         aria-label={t('chat.bookmark.decrementAria') || 'Decrease maximum visible messages'}
         title={t('chat.bookmark.decrementTitle') || 'Decrease'}
       >
         −
       </button>
       <span
-        className="px-2 py-0.5 text-xs font-semibold select-none min-w-[2.5rem] text-center"
+        className="px-2 py-0.5 text-xs font-semibold font-hand select-none min-w-[2.5rem] text-center"
         aria-live="polite"
         aria-atomic="true"
       >
@@ -124,17 +124,17 @@ const BookmarkActions: React.FC<BookmarkActionsProps> = ({ t, message, maxVisibl
         type="button"
         onClick={inc}
         disabled={maxVisibleMessages >= 100}
-        className="px-2 py-0.5 text-xs rounded-full hover:bg-amber-400/30 disabled:opacity-50"
+        className="px-2 py-0.5 text-xs font-hand rounded-sketchy hover:bg-accent/30 disabled:opacity-50"
         aria-label={t('chat.bookmark.incrementAria') || 'Increase maximum visible messages'}
         title={t('chat.bookmark.incrementTitle') || 'Increase'}
       >
         +
       </button>
-      <div className="w-px h-4 bg-primary-foreground/40 mx-1" aria-hidden />
+      <div className="w-px h-4 bg-pencil-light/40 mx-1" aria-hidden />
       <button
         type="button"
         onClick={startEditing}
-        className="px-1.5 py-0.5 rounded-full hover:bg-amber-400/30"
+        className="px-1.5 py-0.5 rounded-sketchy hover:bg-accent/30"
         title="Edit bookmark summary"
         aria-label="Edit bookmark summary"
       >

--- a/src/features/chat/components/ChatMessageBubble.tsx
+++ b/src/features/chat/components/ChatMessageBubble.tsx
@@ -33,6 +33,8 @@ interface ChatMessageBubbleProps {
   transitioningImageId: string | null;
   onSetAttachedImage: (base64: string | null, mimeType: string | null) => void;
   onUserInputActivity: () => void;
+  onQuotaSetupBilling?: () => void;
+  onQuotaStartLive?: () => void;
   registerBubbleEl?: (el: HTMLDivElement | null) => void;
 }
 
@@ -41,6 +43,7 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
   t,
   onToggleSpeakNativeLang, handleSpeakWholeMessage: _handleSpeakWholeMessage, handleSpeakLine, handlePlayUserMessage, speakText, stopSpeaking,
   onToggleImageFocusedMode, transitioningImageId, onSetAttachedImage, onUserInputActivity,
+  onQuotaSetupBilling, onQuotaStartLive,
   registerBubbleEl
 }) => {
   const isUser = message.role === 'user';
@@ -1144,6 +1147,30 @@ const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
                         style={{ fontSize: '3.2cqw', lineHeight: 1.25 }}>
                          {message.text}
                      </p>
+                   )}
+                   {isError && message.errorAction === 'quota' && (
+                     <div className="flex flex-wrap gap-2 mt-2">
+                       {onQuotaSetupBilling && (
+                         <button
+                           type="button"
+                           onClick={onQuotaSetupBilling}
+                           className="inline-flex items-center gap-1.5 px-3 py-1.5 text-accent-foreground bg-accent hover:bg-accent/80 sketchy-border-thin"
+                           style={{ fontSize: '2.8cqw', lineHeight: 1.25 }}
+                         >
+                           {t('error.quotaSetupBilling')}
+                         </button>
+                       )}
+                       {onQuotaStartLive && (
+                         <button
+                           type="button"
+                           onClick={onQuotaStartLive}
+                           className="inline-flex items-center gap-1.5 px-3 py-1.5 text-foreground bg-card hover:bg-muted sketchy-border-thin"
+                           style={{ fontSize: '2.8cqw', lineHeight: 1.25 }}
+                         >
+                           {t('error.quotaStartLive')}
+                         </button>
+                       )}
+                     </div>
                    )}
                    {isAssistant && !message.translations?.length && !message.rawAssistantResponse && !message.imageUrl && !message.isGeneratingImage && message.text && (
                      <p className={`whitespace-pre-wrap ${applyFocusedImageStyles ? 'text-white' : 'text-foreground'}`} style={{ fontSize: '3.6cqw', lineHeight: 1.35 }}>{message.text}</p>

--- a/src/features/chat/hooks/useTutorConversation.ts
+++ b/src/features/chat/hooks/useTutorConversation.ts
@@ -1568,7 +1568,6 @@ export const useTutorConversation = (config: UseTutorConversationConfig): UseTut
           onApiKeyGateOpen?.({ reason: 'missing', instructionIndex: 0 });
         } else if (isQuotaError(error)) {
           errorMessage = t('error.apiQuotaExceeded');
-          onApiKeyGateOpen?.({ reason: 'quota', instructionIndex: 9 });
         } else {
           const parsedMessage = parseApiErrorMessage(error.message);
           errorMessage = parsedMessage || error.code || `HTTP ${error.status}`;
@@ -1576,12 +1575,14 @@ export const useTutorConversation = (config: UseTutorConversationConfig): UseTut
       } else if (error instanceof Error) {
         errorMessage = error.message;
       }
+      const isQuota = error instanceof ApiError && isQuotaError(error);
       updateMessage(thinkingMessageId, {
         thinking: false, 
         role: 'error', 
         text: errorMessage, 
         rawAssistantResponse: undefined, 
         translations: undefined,
+        ...(isQuota ? { errorAction: 'quota' } : {}),
       });
       // Remove sending token on error (replaces setIsSending(false))
       if (sendingTokenRef.current) {

--- a/src/features/session/components/ApiKeyGate.tsx
+++ b/src/features/session/components/ApiKeyGate.tsx
@@ -24,7 +24,7 @@ interface ApiKeyGateProps {
 }
 
 const AI_STUDIO_URL = 'https://aistudio.google.com/app/apikey';
-const PRIVACY_POLICY_URL = 'https://ronitervo.github.io/MaestroTutor/public/privacy.html';
+const PRIVACY_POLICY_URL = 'https://ronitervo.github.io/MaestroTutor/privacy.html';
 const INSTRUCTION_IMAGES = Array.from({ length: 12 }, (_, index) => `${import.meta.env.BASE_URL}api-key-instructions/step-${index + 1}.jpg`);
 const INSTRUCTION_AUTO_ADVANCE_MS = 3200;
 const REGULAR_INSTRUCTIONS_COUNT = 9;


### PR DESCRIPTION
This pull request improves the handling and user experience for Gemini API quota exhaustion scenarios by updating UI actions and error messages, as well as expanding localization support for new actions. The changes ensure users are presented with clearer instructions and options when their free chat quota is depleted, including the ability to set up billing or switch to live conversation, with support across multiple languages.

**Quota Exhaustion Handling and UI Actions:**

- Added new callback handlers in `App.tsx` for quota-related actions: one to guide users to set up billing, and another to initiate a live session if the chat quota is exhausted. These handlers ensure the user is directed appropriately based on their quota status.
- Passed the new quota action handlers as props to the relevant child component to enable these user flows in the UI.

**Localization and Messaging Updates:**

- Updated the error message for API quota exhaustion in all supported languages to remove previous instructions about billing steps, making the message clearer and more concise. [[1]](diffhunk://#diff-473f81b1973925d2b69adc5f6daad2ea99877d5fd220797b87b065d549c6f7a1L237-R239) [[2]](diffhunk://#diff-b076b7bfbf302311920238c10ea469a9b1d4b1fb9b7508ed8ff08bddd66b7d7bL230-R232) [[3]](diffhunk://#diff-921d33d5fda6103db13bf58399ec0189592ecb49b25e5fc22b66a9fc0be5f3a0L232-R234) [[4]](diffhunk://#diff-d90d8de386608ac4c5ad81d632fa1edaa890bbab2a6b10e500bfc62433a9fb64L232-R234) [[5]](diffhunk://#diff-363a0ceb04cb02bcfb30995b42870f3709d17468d7ee7e1d81e83b9104c61fdcL232-R234) [[6]](diffhunk://#diff-53357d433e2c07a48254223844196e9707abf669e7e7c1ba8ae9601f213407daL232-R234) [[7]](diffhunk://#diff-ace4e9cfbeceb490cac6a08c62e89f43c8dbc0b39c5d8b14ea97148b9a0840aeL232-R234) [[8]](diffhunk://#diff-1ee0bb91bd5963611a6cc4c1b4c809395f70cbc5322730dd7f83316893589306L232-R234) [[9]](diffhunk://#diff-8c3ae813f34666ed48409ef562d50e76974f240488652ddfa37a2ce2cb9c0472L232-R234) [[10]](diffhunk://#diff-070d7e969176e0aaace751eb95e7bb531c7dd2c1deb9f8e8f737eaa93207e0c1L232-R234) [[11]](diffhunk://#diff-b78416e18f0dde46b082694bb87900152d93eb10026673d7c107aca8424eeffdL232-R234) [[12]](diffhunk://#diff-525e97bd9d0e74db3a3d6d0d5ebc85c9f0299b93478efc482b68ae854902c201L232-R234) [[13]](diffhunk://#diff-6941449f26e595dc9975a48dd1cfe9640a4a56aaa6b77da8a7b63a037c267a35L232-R234) [[14]](diffhunk://#diff-1643e7007fcdba7f804c11e06ccea9a6a4fe9d3981c270e14444098c6b2e7079L232-R234) [[15]](diffhunk://#diff-18544695bd7ac692b0ebd1d9cf294bf3770bf1cbef8e92b0a549e0f30c0d6994L232-R234) [[16]](diffhunk://#diff-26f2b43dff187e5c67d7c43b8e90f539647f98db2a2f5c89b69ddc6cfdcfd88eL232-R234)
- Added new localized strings for "Set up billing" and "Start Live instead" actions in all supported languages, ensuring users receive clear action prompts in their preferred language. [[1]](diffhunk://#diff-473f81b1973925d2b69adc5f6daad2ea99877d5fd220797b87b065d549c6f7a1L237-R239) [[2]](diffhunk://#diff-b076b7bfbf302311920238c10ea469a9b1d4b1fb9b7508ed8ff08bddd66b7d7bL230-R232) [[3]](diffhunk://#diff-921d33d5fda6103db13bf58399ec0189592ecb49b25e5fc22b66a9fc0be5f3a0L232-R234) [[4]](diffhunk://#diff-d90d8de386608ac4c5ad81d632fa1edaa890bbab2a6b10e500bfc62433a9fb64L232-R234) [[5]](diffhunk://#diff-363a0ceb04cb02bcfb30995b42870f3709d17468d7ee7e1d81e83b9104c61fdcL232-R234) [[6]](diffhunk://#diff-53357d433e2c07a48254223844196e9707abf669e7e7c1ba8ae9601f213407daL232-R234) [[7]](diffhunk://#diff-ace4e9cfbeceb490cac6a08c62e89f43c8dbc0b39c5d8b14ea97148b9a0840aeL232-R234) [[8]](diffhunk://#diff-1ee0bb91bd5963611a6cc4c1b4c809395f70cbc5322730dd7f83316893589306L232-R234) [[9]](diffhunk://#diff-8c3ae813f34666ed48409ef562d50e76974f240488652ddfa37a2ce2cb9c0472L232-R234) [[10]](diffhunk://#diff-070d7e969176e0aaace751eb95e7bb531c7dd2c1deb9f8e8f737eaa93207e0c1L232-R234) [[11]](diffhunk://#diff-b78416e18f0dde46b082694bb87900152d93eb10026673d7c107aca8424eeffdL232-R234) [[12]](diffhunk://#diff-525e97bd9d0e74db3a3d6d0d5ebc85c9f0299b93478efc482b68ae854902c201L232-R234) [[13]](diffhunk://#diff-6941449f26e595dc9975a48dd1cfe9640a4a56aaa6b77da8a7b63a037c267a35L232-R234) [[14]](diffhunk://#diff-1643e7007fcdba7f804c11e06ccea9a6a4fe9d3981c270e14444098c6b2e7079L232-R234) [[15]](diffhunk://#diff-18544695bd7ac692b0ebd1d9cf294bf3770bf1cbef8e92b0a549e0f30c0d6994L232-R234) [[16]](diffhunk://#diff-26f2b43dff187e5c67d7c43b8e90f539647f98db2a2f5c89b69ddc6cfdcfd88eL232-R234)

**Documentation:**

- Fixed the privacy policy URL in the release checklist documentation to point to the correct location.