### PR TITLE
feat: Scroll to bottom when message updates and near bottom.

### DIFF
--- a/src/features/chat/components/ChatInterface.tsx
+++ b/src/features/chat/components/ChatInterface.tsx
@@ -169,6 +169,20 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const shouldAutoScrollRef = useRef(true);
+
+  const handleContainerScroll = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+    shouldAutoScrollRef.current = distanceFromBottom < 500;
+  }, []);
+
+  useEffect(() => {
+    if (shouldAutoScrollRef.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages]);
 
   const [bookmarkViewMode, setBookmarkViewMode] = useState<'below' | 'above'>('below');
   const [bookmarkAboveChunkIndex, setBookmarkAboveChunkIndex] = useState(0);
@@ -555,9 +569,10 @@ const ChatInterface: React.FC<ChatInterfaceProps> = (props) => {
 
   return (
     <div className="flex flex-col h-full bg-background notebook-lines">
-      <div 
+      <div
         ref={scrollContainerRef}
         className="flex-grow overflow-y-auto p-4"
+        onScroll={handleContainerScroll}
         onPointerMove={handleSwipePointerMove}
         onPointerUp={handleSwipePointerUp}
         onPointerCancel={handleSwipePointerCancel}


### PR DESCRIPTION
This pull request improves the chat scrolling experience in the `ChatInterface` component by making auto-scrolling smarter. The main change ensures that the chat will only auto-scroll to the bottom when the user is already near the bottom, preventing unwanted jumps when the user is reading earlier messages.

**Chat scrolling improvements:**

* Added logic to track whether the user is near the bottom of the chat (`shouldAutoScrollRef`), and only auto-scroll to the latest message if they are within 500px of the bottom. This prevents interrupting users who are reading previous messages. (`src/features/chat/components/ChatInterface.tsx`, [src/features/chat/components/ChatInterface.tsxR172-R185](diffhunk://#diff-ab3ce8aa9f629761724d3403d751413073de8a5e173c321203a95d8e802e2b48R172-R185))
* Attached the new scroll handler (`handleContainerScroll`) to the chat container's `onScroll` event to update the auto-scroll state as the user scrolls. (`src/features/chat/components/ChatInterface.tsx`, [src/features/chat/components/ChatInterface.tsxR575](diffhunk://#diff-ab3ce8aa9f629761724d3403d751413073de8a5e173c321203a95d8e802e2b48R575))