### PR TITLE
feat: checked and applied recommended fixes

### DIFF
--- a/src/features/session/hooks/useSmartReengagement.ts
+++ b/src/features/session/hooks/useSmartReengagement.ts
@@ -38,7 +38,7 @@ export const useSmartReengagement = ({
   const reengagementTokensRef = useRef<{ waitToken: string | null; countdownToken: string | null }>({ waitToken: null, countdownToken: null });
   const reengagementDeadlineRef = useRef<number | null>(null);
   const isUserActiveRef = useRef<boolean>(false);
-  const userActiveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const userActiveTimerRef = useRef<number | null>(null);
   
   // Refs to store the latest versions of interdependent functions
   // This breaks the circular dependency chain by allowing functions to call
@@ -249,15 +249,25 @@ export const useSmartReengagement = ({
     isUserActiveRef.current = true;
     setIsUserActive(true);
     cancelReengagementRef.current();
-    if (userActiveTimerRef.current) {
-      clearTimeout(userActiveTimerRef.current);
+    if (userActiveTimerRef.current !== null) {
+      window.clearTimeout(userActiveTimerRef.current);
     }
-    userActiveTimerRef.current = setTimeout(() => {
+    userActiveTimerRef.current = window.setTimeout(() => {
       userActiveTimerRef.current = null;
       isUserActiveRef.current = false;
       setIsUserActive(false);
     }, 3000);
   }, [setIsUserActive]);
+
+  // Cleanup userActiveTimer on unmount to prevent stale setIsUserActive calls
+  useEffect(() => {
+    return () => {
+      if (userActiveTimerRef.current !== null) {
+        window.clearTimeout(userActiveTimerRef.current);
+        userActiveTimerRef.current = null;
+      }
+    };
+  }, []);
 
   return {
     reengagementPhase,

--- a/src/features/speech/hooks/useGeminiLiveConversation.ts
+++ b/src/features/speech/hooks/useGeminiLiveConversation.ts
@@ -440,7 +440,7 @@ export function useGeminiLiveConversation(
                     const points = modelAudioSplitPointsRef.current
                         .slice()
                         .sort((a, b) => a - b)
-                        .filter(p => p > 0 && p < modelAudioFull.length);
+                        .filter(p => p < modelAudioFull.length);
 
                     for (const point of points) {
                         if (point > startSample) {


### PR DESCRIPTION
This pull request introduces improvements to the `useSmartReengagement` and `useGeminiLiveConversation` hooks, primarily focusing on timer management and cleanup, as well as a minor adjustment to audio split point filtering. The main goal is to ensure robust resource handling and prevent potential issues from stale timers or invalid filter conditions.

**Timer management and cleanup improvements (`useSmartReengagement.ts`):**
- Changed the type of `userActiveTimerRef` from `ReturnType<typeof setTimeout>` to `number | null` for consistency with browser timer APIs.
- Updated timer usage to explicitly use `window.setTimeout` and `window.clearTimeout` for clarity and to avoid ambiguity in different environments.
- Added a `useEffect` cleanup to clear any active `userActiveTimerRef` on component unmount, preventing potential memory leaks or stale state updates.

**Audio split point filtering adjustment (`useGeminiLiveConversation.ts`):**
- Modified the filter condition for `modelAudioSplitPointsRef` to remove the redundant check for points greater than zero, now only filtering for points less than the audio length.