### PR TITLE
feat: check and fix useractive timer releated code

### DIFF
--- a/src/features/session/hooks/useSmartReengagement.ts
+++ b/src/features/session/hooks/useSmartReengagement.ts
@@ -266,8 +266,13 @@ export const useSmartReengagement = ({
         window.clearTimeout(userActiveTimerRef.current);
         userActiveTimerRef.current = null;
       }
+      // Reset store flag on unmount so isUserActive doesn't stay stuck true
+      if (isUserActiveRef.current) {
+        isUserActiveRef.current = false;
+        setIsUserActive(false);
+      }
     };
-  }, []);
+  }, [setIsUserActive]);
 
   return {
     reengagementPhase,


### PR DESCRIPTION
This pull request makes a small but important improvement to the `useSmartReengagement` hook. It ensures that the `isUserActive` state is properly reset when the component unmounts, preventing the flag from remaining stuck as `true`.

* Ensures `isUserActive` is reset to `false` on unmount in `useSmartReengagement.ts` to prevent stale state.