### PR TITLE
Use dedicated Gemini Live audio and video inputs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -17,8 +17,8 @@ android {
         applicationId "com.ronitervo.maestrotutor"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 61
-        versionName "2.1.3"
+        versionCode 62
+        versionName "2.1.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     androidResources {

--- a/src/features/speech/hooks/useGeminiLiveConversation.ts
+++ b/src/features/speech/hooks/useGeminiLiveConversation.ts
@@ -637,7 +637,7 @@ export function useGeminiLiveConversation(
             if (blob && sessionRef.current && currentSessionIdRef.current === sessionId) {
               const b64 = await blobToBase64(blob);
               if (currentSessionIdRef.current !== sessionId) return;
-              sessionRef.current.sendRealtimeInput({ media: { data: b64, mimeType: 'image/jpeg' } });
+              sessionRef.current.sendRealtimeInput({ video: { data: b64, mimeType: 'image/jpeg' } });
             }
           } finally {
             videoFrameInFlightRef.current = false;
@@ -1242,7 +1242,7 @@ export function useGeminiLiveConversation(
             const base64 = await ensureInputCodecWorker().encodePcmToBase64(transferBuffer);
             if (currentSessionIdRef.current !== sessionId) return;
             sessionRef.current?.sendRealtimeInput({
-              media: {
+              audio: {
                 data: base64,
                 mimeType: `audio/pcm;rate=${INPUT_SAMPLE_RATE}`,
               },

--- a/src/features/speech/hooks/useGeminiLiveStt.ts
+++ b/src/features/speech/hooks/useGeminiLiveStt.ts
@@ -600,7 +600,7 @@ export function useGeminiLiveStt(options?: UseGeminiLiveSttOptions): UseGeminiLi
             if (currentSessionIdRef.current !== sessionId) return;
             if (!sessionRef.current) return;
             sessionRef.current.sendRealtimeInput({
-              media: {
+              audio: {
                 data: base64,
                 mimeType: `audio/pcm;rate=${INPUT_SAMPLE_RATE}`,
               },

--- a/src/features/speech/services/geminiLiveAudioNote.ts
+++ b/src/features/speech/services/geminiLiveAudioNote.ts
@@ -207,7 +207,7 @@ export const synthesizeGeminiAudioNote = async (params: {
 
           try {
             session.sendRealtimeInput({
-              media: {
+              audio: {
                 mimeType: `audio/pcm;rate=${TRIGGER_SAMPLE_RATE}`,
                 data: base64Chunk,
               },

--- a/src/features/speech/services/geminiLiveTts.ts
+++ b/src/features/speech/services/geminiLiveTts.ts
@@ -519,7 +519,7 @@ ${textBlock}`;
 
         try {
           session.sendRealtimeInput({
-            media: { mimeType: `audio/pcm;rate=${TRIGGER_SAMPLE_RATE}`, data: b64Data }
+            audio: { mimeType: `audio/pcm;rate=${TRIGGER_SAMPLE_RATE}`, data: b64Data }
           });
         } catch (e) {
           cleanup();


### PR DESCRIPTION
## Summary

- send microphone, STT, TTS-trigger, and audio-note PCM through `sendRealtimeInput({ audio })`
- send camera JPEG frames through `sendRealtimeInput({ video })`
- remove every remaining `sendRealtimeInput({ media })` call

## Why

`@google/genai` converts the legacy `media` parameter into `realtime_input.media_chunks`, which the Gemini Live API now reports as deprecated. The SDK's dedicated `audio` and `video` parameters map to the current wire fields and preserve the existing payloads, MIME types, packet timing, and session behavior.

## User impact

Live conversation, camera context, speech recognition, spoken replies, and audio notes no longer use the deprecated realtime media field. No visible behavior or pricing behavior changes.

## Validation

- verified no `sendRealtimeInput({ media })` payloads remain
- `npm test` — 27 tests passed
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
